### PR TITLE
Twitter icons overflow

### DIFF
--- a/apps/web/src/features/misc/pages/about.tsx
+++ b/apps/web/src/features/misc/pages/about.tsx
@@ -240,7 +240,7 @@ const Professors = () => {
 
 const ActiveContributors = () => {
   const { t } = useTranslation();
-  const css = 'w-24 h-24 rounded-lg';
+  const css = 'w-24 h-24 rounded-full';
 
   return (
     <div className="mt-20 flex w-full max-w-5xl flex-col gap-4">

--- a/apps/web/src/features/misc/pages/home.tsx
+++ b/apps/web/src/features/misc/pages/home.tsx
@@ -111,7 +111,7 @@ export const Home = () => {
           </div>
           <div className="relative col-span-3 hidden items-start lg:flex">
             <img
-              className="z-10 -ml-16 mt-8 h-[18rem] w-auto xl:h-[24rem]"
+              className="z-10 -ml-16 mt-8 h-72 w-auto xl:h-96"
               src={HeaderPill}
               alt={t('imagesAlt.orangePill')}
               loading="lazy"
@@ -336,9 +336,11 @@ export const Home = () => {
             width={50}
             className="rounded-full"
           />
-          <div className="ml-4">
-            <p className="font-bold leading-4 text-orange-500">{name}</p>
-            <p className="font-medium text-gray-400">{handle}</p>
+          <div className="ml-4 flex-auto min-w-[90px]">
+            <p className="font-bold leading-4 text-orange-500 truncate">
+              {name}
+            </p>
+            <p className="font-medium text-gray-400 truncate">{handle}</p>
           </div>
           <div className="ml-auto mr-4 mt-2">
             <a


### PR DESCRIPTION
Keep the twitter icon from overflow of his boxe on small screens.
On small screens the twitter user name will shrink until 90px to
keep the twitter icon inside the box (resolves #213, resolves #206) 