### PR TITLE
fix: search text is visible #221

### DIFF
--- a/apps/web/src/features/resources/components/FilterBar/index.tsx
+++ b/apps/web/src/features/resources/components/FilterBar/index.tsx
@@ -27,7 +27,7 @@ export const FilterBar = ({
             setValue(event.target.value);
             onChange(event.target.value);
           }}
-          className="inline-block h-fit w-full max-w-md rounded-full border-0 bg-gray-100 py-1 pl-4 text-sm placeholder:text-gray-500 placeholder:text-opacity-50 focus:border-gray-100 focus:outline-none focus:ring focus:ring-gray-300 sm:max-w-xl sm:text-base"
+          className="inline-block h-fit w-full max-w-md rounded-full border-0 bg-gray-100 py-1 pl-4 text-sm placeholder:text-gray-500 placeholder:text-opacity-50 focus:border-gray-100 focus:outline-none focus:ring focus:ring-gray-300 sm:max-w-xl sm:text-base caret-orange-500 text-blue-800"
         />
       </div>
       {/* <button className="text-right font-light italic underline">


### PR DESCRIPTION
This changes resolves #221 (if it hasn’t been already solved) by changing the caret color to orange and the search bar to a darker tone