### PR TITLE
fix: improve sync time

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ POSTGRES_DB=postgres
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 SESSION_SECRET=nursery-skiing-decade-bazooka-glade-dart-lurch-skewed-wrist-sponsor-junkman-sandstorm
+SYNC_PATH=/tmp/sync
 CDN_PATH=/tmp/cdn
 CDN_URL=http://localhost:8080
 

--- a/README.md
+++ b/README.md
@@ -46,10 +46,8 @@ In order to sync the database with the data from the data repository, you can ma
 
 ### Sync issue
 
-When running the sync locally, there is currently and access right issue with the cdn volume. To fix it, find where the volume named sovereign-university_cdn is located (using `docker volume inspect sovereign-university_cdn`).
-
-Then update the access rights on this folder :
-`sudo chmod 777 /var/lib/docker/volumes/sovereign-university_cdn/_data`
+When running the sync locally, there is currently and access right issue with the cdn and sync volumes. To fix it, update the access rights with the following command :
+`docker exec --user=root sovereign-university-api-1 chmod 777 /tmp/{sync,cdn}`
 
 ## Development - Manage the database
 

--- a/apps/api/src/services/github/sync.ts
+++ b/apps/api/src/services/github/sync.ts
@@ -6,6 +6,7 @@ import {
   createProcessDeleteOldEntities,
 } from '@sovereign-university/content';
 import {
+  computeTemporaryDirectory,
   getAllRepoFiles,
   syncCdnRepository,
 } from '@sovereign-university/github';
@@ -68,7 +69,7 @@ export async function syncGithubRepositories(dependencies: Dependencies) {
   ) {
     try {
       await syncCdnRepository(
-        '/tmp/sovereign-university-data-paid',
+        computeTemporaryDirectory(process.env['PRIVATE_DATA_REPOSITORY_URL']),
         process.env['CDN_PATH'] || '/tmp/cdn',
       );
     } catch (error) {
@@ -81,7 +82,7 @@ export async function syncGithubRepositories(dependencies: Dependencies) {
   let publicCdnError;
   try {
     await syncCdnRepository(
-      '/tmp/sovereign-university-data',
+      computeTemporaryDirectory(process.env['DATA_REPOSITORY_URL']),
       process.env['CDN_PATH'] || '/tmp/cdn',
     );
   } catch (error) {

--- a/compose.yml
+++ b/compose.yml
@@ -88,6 +88,7 @@ services:
       - ./packages/types/src:/home/node/packages/types/src
       - ./packages/user/src:/home/node/packages/user/src
       - cdn:$CDN_PATH
+      - sync:${SYNC_PATH:-/tmp/sync}
     depends_on:
       - postgres
     healthcheck:
@@ -115,3 +116,4 @@ volumes:
   postgres:
   redis:
   cdn:
+  sync:

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -10,3 +10,4 @@ POSTGRES_USER=postgres
 POSTGRES_DB=postgres
 
 CDN_PATH=/tmp/cdn
+SYNC_PATH=/tmp/sync

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -47,6 +47,7 @@ services:
       - 3000
     volumes:
       - ./data/cdn:$CDN_PATH
+      - ./data/sync:$SYNC_PATH
     labels:
       - traefik.enable=true
       - traefik.http.routers.university-api-${ENV}.rule=Host(`api.${DOMAIN}`)


### PR DESCRIPTION
This PR adds some improvements:
  - Git shallow clone (only fetch the last commit of a given branch when cloning) brings the sync data dir from ~600M (41k objects) to ~150M (12k objects) 
  - Using a volume for data sync: recovers the previous git clone
 
Sync now takes 1 to 2 minutes when cloning the project and 30 to 60 seconds when pulling