### PR TITLE
Others tutorials descriptions

### DIFF
--- a/apps/web/public/locales/de.json
+++ b/apps/web/public/locales/de.json
@@ -558,10 +558,22 @@
             "title": "Wallet"
         },
         "others": {
-            "title": "",
-            "shortDescription": "",
-            "description": ""
-        }
+            "title": "Andere",
+            "shortDescription": "Alle unsere verschiedenen Tutorials",
+            "description": "Erkunden Sie diesen Abschnitt, um eine Reihe von Tutorials zu Bitcoin und verschiedenen Werkzeugen zu entdecken.",
+            "DIY": {
+                "description": "Entdecken Sie unsere DIY-Tutorials, um zu lernen, wie man Dinge im Zusammenhang mit Bitcoin, Informatik und individueller Souveränität selbst erstellt!"
+            },
+            "OpenSource": {
+                "description": "Erkunden Sie unsere Tutorials zur Nutzung von Open-Source-Tools!"
+            },
+            "Contribution": {
+                "description": "Erfahren Sie, wie Sie zum PlanB Network beitragen und die Open-Source-Tools, die wir intern verwenden, durch unsere detaillierten Tutorials beherrschen!"
+            },
+            "General": {
+                "description": "Durchsuchen Sie unsere allgemeinen Tutorials, um Ihr Wissen in Informatik und anderen Themen im Zusammenhang mit individueller Souveränität zu bereichern!"
+            }
+        }    
     },
     "underConstruction": {
         "github": "GitHub",

--- a/apps/web/public/locales/en.json
+++ b/apps/web/public/locales/en.json
@@ -545,9 +545,21 @@
       "title": "Node"
     },
     "others": {
-      "title": "Others",
-      "shortDescription": "",
-      "description": ""
+        "title": "Others",
+        "shortDescription": "All our miscellaneous tutorials",
+        "description": "Explore this section to discover a series of tutorials dedicated to Bitcoin and various tools.",
+        "DIY": {
+            "description": "Discover our DIY tutorials to learn how to create things related to Bitcoin, computing, and individual sovereignty by yourself!"
+        },
+        "OpenSource": {
+            "description": "Explore our tutorials dedicated to the use of open-source tools!"
+        },
+        "Contribution": {
+            "description": "Learn how to contribute to PlanB Network and master the open-source tools we use internally through our detailed tutorials!"
+        },
+        "General": {
+            "description": "Browse our general tutorials to enrich your knowledge in computing and other subjects related to individual sovereignty!"
+        }
     },
     "pageDescription": "Bitcoin is a wide industry, that becomes wider and wider everyday. To help you explore it, we’ve gathered and curated a large number of tutorials that describe various solutions in all domains related to Bitcoin.",
     "pageSubtitle": "Let's demystify Bitcoin by showing the vastness and richness of its ecosystem",

--- a/apps/web/public/locales/es.json
+++ b/apps/web/public/locales/es.json
@@ -558,10 +558,22 @@
             "title": "Billetera"
         },
         "others": {
-            "title": "",
-            "shortDescription": "",
-            "description": ""
-        }
+            "title": "Otros",
+            "shortDescription": "Todos nuestros tutoriales diversos",
+            "description": "Explore esta sección para descubrir una serie de tutoriales dedicados a Bitcoin y diversas herramientas.",
+            "DIY": {
+                "description": "¡Descubre nuestros tutoriales DIY para aprender a crear cosas relacionadas con Bitcoin, la informática y la soberanía individual por ti mismo!"
+            },
+            "OpenSource": {
+                "description": "¡Explora nuestros tutoriales dedicados al uso de herramientas de código abierto!"
+            },
+            "Contribution": {
+                "description": "¡Aprende cómo contribuir a PlanB Network y domina las herramientas de código abierto que usamos internamente a través de nuestros tutoriales detallados!"
+            },
+            "General": {
+                "description": "¡Explora nuestros tutoriales generales para enriquecer tus conocimientos en informática y otros temas relacionados con la soberanía individual!"
+            }
+        }    
     },
     "underConstruction": {
         "github": "GitHub",

--- a/apps/web/public/locales/fr.json
+++ b/apps/web/public/locales/fr.json
@@ -558,9 +558,21 @@
             "title": "Portefeuille"
         },
         "others": {
-            "title": "",
-            "shortDescription": "",
-            "description": ""
+            "title": "Autres",
+            "shortDescription": "Tous nos tutoriels divers",
+            "description": "Explorez cette section pour découvrir une série de tutoriels dédiés à Bitcoin et aux outils divers.",
+            "DIY": {
+                "description": "Découvrez nos tutoriels DIY pour apprendre à créer par vous-même des choses liées à Bitcoin, à l'informatique, et à la souveraineté individuelle !"
+            },
+            "OpenSource": {
+                "description": "Explorez nos tutoriels consacrés à l'utilisation des outils open-source !"
+            },
+            "Contribution": {
+                "description": "Apprenez comment contribuer à PlanB Network et maîtrisez les outils open-source que nous utilisons en interne à travers nos tutoriels détaillés !"
+            },
+            "General": {
+                "description": "Parcourez nos tutoriels généralistes pour enrichir vos connaissances en informatique et sur d'autres sujets en lien avec la souveraineté individuelle !"
+            }
         }
     },
     "underConstruction": {

--- a/apps/web/public/locales/it.json
+++ b/apps/web/public/locales/it.json
@@ -558,10 +558,23 @@
             "title": "Portafoglio"
         },
         "others": {
-            "shortDescription": "",
-            "title": "",
-            "description": ""
+            "title": "Altri",
+            "shortDescription": "Tutti i nostri tutorial vari",
+            "description": "Esplora questa sezione per scoprire una serie di tutorial dedicati a Bitcoin e vari strumenti.",
+            "DIY": {
+                "description": "Scopri i nostri tutorial fai-da-te per imparare a creare cose legate a Bitcoin, informatica e sovranità individuale da solo!"
+            },
+            "OpenSource": {
+                "description": "Esplora i nostri tutorial dedicati all'uso di strumenti open-source!"
+            },
+            "Contribution": {
+                "description": "Impara come contribuire a PlanB Network e padroneggia gli strumenti open-source che usiamo internamente attraverso i nostri tutorial dettagliati!"
+            },
+            "General": {
+                "description": "Esplora i nostri tutorial generali per arricchire le tue conoscenze in informatica e altri argomenti legati alla sovranità individuale!"
+            }
         }
+    
     },
     "underConstruction": {
         "github": "GitHub",

--- a/apps/web/public/locales/pt.json
+++ b/apps/web/public/locales/pt.json
@@ -558,10 +558,22 @@
             "title": "Carteira (Wallet)"
         },
         "others": {
-            "title": "",
-            "shortDescription": "",
-            "description": ""
-        }
+            "title": "Outros",
+            "shortDescription": "Todos os nossos tutoriais diversos",
+            "description": "Explore esta seção para descobrir uma série de tutoriais dedicados ao Bitcoin e a várias ferramentas.",
+            "DIY": {
+                "description": "Descubra nossos tutoriais DIY para aprender a criar coisas relacionadas ao Bitcoin, informática e soberania individual por conta própria!"
+            },
+            "OpenSource": {
+                "description": "Explore nossos tutoriais dedicados ao uso de ferramentas de código aberto!"
+            },
+            "Contribution": {
+                "description": "Aprenda a contribuir para a PlanB Network e domine as ferramentas de código aberto que usamos internamente através de nossos tutoriais detalhados!"
+            },
+            "General": {
+                "description": "Explore nossos tutoriais gerais para enriquecer seu conhecimento em informática e outros temas relacionados à soberania individual!"
+            }
+        }    
     },
     "underConstruction": {
         "github": "GitHub",


### PR DESCRIPTION
Added missing descriptions in the JSON files for the new /others section in the tutorials. Six languages have been completed: FR (French), EN (English), DE (German), ES (Spanish), IT (Italian), and PT (Portuguese). If needed, I can do more, but it seems that the JSON files are in English for all other languages.