### PR TITLE
Fix slow web app compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ Thumbs.db
 **/.env
 
 .turbo
+.vite
 out
 tsconfig.*.tsbuildinfo
 *storybook.log
+*.cpuprofile

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -63,6 +63,7 @@
     "@types/react-syntax-highlighter": "15.5.13",
     "@vitejs/plugin-react": "4.2.1",
     "sass": "^1.77.0",
+    "tailwindcss": "^3.4.3",
     "vite-plugin-svgr": "^4.2.0"
   }
 }

--- a/apps/web/src/features/dashboard/pages/dashboard-profile.tsx
+++ b/apps/web/src/features/dashboard/pages/dashboard-profile.tsx
@@ -66,6 +66,7 @@ export const DashboardProfile = () => {
                   className="rounded-md bg-[#e9e9e9] px-4 py-1 text-gray-400 border border-gray-400/10"
                 />
               </div>
+
               <div className="mt-6 flex flex-col">
                 <label htmlFor="displayName">Display Name</label>
                 <input

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -1,15 +1,12 @@
-import { join } from 'node:path';
-
 import type { Config } from 'tailwindcss';
 
 import baseConfig from '../../packages/ui/tailwind.config-base.js';
 
 export default {
   content: [
-    join(
-      '{src,pages,components,app,atoms}/**/*!(*.stories|*.spec).{ts,tsx,html}',
-    ),
-    '../../packages/ui/**/*.{js,jsx,ts,tsx}',
+    './src/**/*!(*.stories|*.spec).{ts,tsx,html}',
+    '../../packages/ui/src/**/*.{ts,tsx}',
+    '../../packages/ui/storybook/**/*.{ts,tsx}',
   ],
   presets: [baseConfig],
 } satisfies Config;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
+    "dev": "dotenv -- turbo dev --cache-dir=.turbo",
+    "dev:web": "dotenv -- turbo dev --cache-dir=.turbo --filter=web",
+    "dev:api": "dotenv -- turbo dev --cache-dir=.turbo --filter=api",
     "build": "turbo run build --cache-dir=.turbo",
     "docker:dev": "docker compose pull && docker compose up -d --remove-orphans postgres redis && docker compose up -d --build --renew-anon-volumes api web cdn && docker compose exec -u 0:0 api sh -c 'echo $CDN_PATH'",
     "build:packages": "turbo run build --filter='./packages/*'",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,6 +300,9 @@ importers:
       sass:
         specifier: ^1.77.0
         version: 1.77.0
+      tailwindcss:
+        specifier: ^3.4.3
+        version: 3.4.3
       vite-plugin-svgr:
         specifier: ^4.2.0
         version: 4.2.0(rollup@4.17.2)(typescript@5.4.5)(vite@5.2.11(@types/node@20.12.11)(sass@1.77.0))
@@ -9922,14 +9925,14 @@ snapshots:
 
   '@radix-ui/react-compose-refs@1.0.1(@types/react@18.2.74)(react@18.2.0)':
     dependencies:
-      '@babel/runtime': 7.24.4
+      '@babel/runtime': 7.24.5
       react: 18.2.0
     optionalDependencies:
       '@types/react': 18.2.74
 
   '@radix-ui/react-compose-refs@1.0.1(@types/react@18.3.1)(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.24.4
+      '@babel/runtime': 7.24.5
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.1
@@ -11171,7 +11174,7 @@ snapshots:
   '@testing-library/dom@9.3.4':
     dependencies:
       '@babel/code-frame': 7.24.2
-      '@babel/runtime': 7.24.4
+      '@babel/runtime': 7.24.5
       '@types/aria-query': 5.0.4
       aria-query: 5.1.3
       chalk: 4.1.2
@@ -11182,7 +11185,7 @@ snapshots:
   '@testing-library/jest-dom@6.4.2(vitest@1.6.0(@types/node@20.12.11)(@vitest/ui@1.5.0(vitest@1.5.0))(jsdom@24.0.0)(sass@1.77.0))':
     dependencies:
       '@adobe/css-tools': 4.3.3
-      '@babel/runtime': 7.24.4
+      '@babel/runtime': 7.24.5
       aria-query: 5.3.0
       chalk: 3.0.0
       css.escape: 1.5.1
@@ -15901,7 +15904,7 @@ snapshots:
 
   polished@4.3.1:
     dependencies:
-      '@babel/runtime': 7.24.4
+      '@babel/runtime': 7.24.5
 
   possible-typed-array-names@1.0.0: {}
 
@@ -16301,7 +16304,7 @@ snapshots:
 
   regenerator-transform@0.15.2:
     dependencies:
-      '@babel/runtime': 7.24.4
+      '@babel/runtime': 7.24.5
 
   regexp-tree@0.1.27: {}
 


### PR DESCRIPTION
Performing `vite --profile` (https://vitejs.dev/guide/performance) in apps/web shows that tailwinds take a anormal time to parse files. This is due to a tailwind misconfiguration that makes tailwind looks into packages/ui/node_modules.

