### PR TITLE
Various front-end fixes

### DIFF
--- a/apps/web/public/locales/en.json
+++ b/apps/web/public/locales/en.json
@@ -427,6 +427,7 @@
     "needHelp": "Need help defining a technical word ?",
     "keepLooking": "Wanna keep looking ?",
     "loadMoreWords": "Load more words",
+    "notTranslated": "The data in the glossary has not been translated yet.\nIf you would like like to help, feel free to contribute on our",
     "pageSubtitle": "Need help defining a technical word ?",
     "pageTitle": "Bitcoin Glossary",
     "placeHolder": "What is this ?",

--- a/apps/web/src/components/GlossaryMarkdownBody/index.tsx
+++ b/apps/web/src/components/GlossaryMarkdownBody/index.tsx
@@ -58,7 +58,7 @@ export const GlossaryMarkdownBody = ({
           <h3 className="ml-2 text-xl font-semibold text-white">{children}</h3>
         ),
         p: ({ children }) => (
-          <p className="mobile-body2 md:desktop-body1 text-white my-1 last:mb-0">
+          <p className="mobile-body2 md:desktop-body1 text-white my-3 last:mb-0">
             {children}
           </p>
         ),

--- a/apps/web/src/components/MarkdownComponents/blockquote.tsx
+++ b/apps/web/src/components/MarkdownComponents/blockquote.tsx
@@ -18,8 +18,6 @@ export const Blockquote = ({
         )
     : children;
 
-  console.log(filteredChildren);
-
   return (
     <div className="flex p-2 rounded-lg bg-newGray-5">
       <FaQuoteLeft className="shrink-0 size-2 md:size-4" />

--- a/apps/web/src/components/MarkdownComponents/blockquote.tsx
+++ b/apps/web/src/components/MarkdownComponents/blockquote.tsx
@@ -1,33 +1,30 @@
 import type { ReactNode } from 'react';
-import { isValidElement } from 'react';
 import { FaQuoteLeft, FaQuoteRight } from 'react-icons/fa6';
-
-// Flatten children and extract text, avoid issue with blockquote reference not being parsed correctly
-const extractTextFromChildren = (children: ReactNode): string => {
-  if (Array.isArray(children)) {
-    return children.map((child) => extractTextFromChildren(child)).join(' ');
-  }
-  if (typeof children === 'string' || typeof children === 'number') {
-    return children.toString();
-  }
-  if (isValidElement(children) && children.props.children) {
-    return extractTextFromChildren(children.props.children);
-  }
-  return '';
-};
 
 export const Blockquote = ({
   children,
 }: {
   children: ReactNode | Iterable<ReactNode>;
 }) => {
-  const textContent = extractTextFromChildren(children);
+  const filteredChildren = Array.isArray(children)
+    ? children
+        .slice(1, -1)
+        .map((child) =>
+          child && child.props && child.props.node.tagName === 'p'
+            ? child.props.children
+            : child === '\n'
+              ? '\n\n'
+              : child,
+        )
+    : children;
+
+  console.log(filteredChildren);
 
   return (
     <div className="flex p-2 rounded-lg bg-newGray-5">
       <FaQuoteLeft className="shrink-0 size-2 md:size-4" />
-      <blockquote className="max-md:text-center mobile-body2 md:desktop-body1 mx-2 md:mx-4 italic">
-        {textContent}
+      <blockquote className="max-md:text-center mobile-body2 md:desktop-body1 mx-2 md:mx-4 italic whitespace-pre-line">
+        {filteredChildren}
       </blockquote>
       <FaQuoteRight className="self-end shrink-0 size-2 md:size-4" />
     </div>

--- a/apps/web/src/components/PageHeader/index.tsx
+++ b/apps/web/src/components/PageHeader/index.tsx
@@ -11,6 +11,7 @@ export const PageHeader = ({
   hasGithubDescription = false,
   hideOnMobile,
   removeTopMargin,
+  increaseHorizontalPadding,
 }: {
   title: string;
   subtitle?: string;
@@ -19,15 +20,17 @@ export const PageHeader = ({
   hasGithubDescription?: boolean;
   hideOnMobile?: boolean;
   removeTopMargin?: boolean;
+  increaseHorizontalPadding?: boolean;
 }) => {
   const isSubsectionTitle = subtitle ? false : true;
 
   return (
     <div
       className={cn(
-        'flex flex-col max-lg:px-4',
+        'flex flex-col',
         hideOnMobile && 'max-md:hidden',
         removeTopMargin ? '' : 'mt-5 md:mt-10',
+        increaseHorizontalPadding ? 'max-lg:px-6' : 'max-lg:px-4',
       )}
     >
       {subtitle && (

--- a/apps/web/src/routes/_content/courses/$courseId/$chapterId.tsx
+++ b/apps/web/src/routes/_content/courses/$courseId/$chapterId.tsx
@@ -135,7 +135,7 @@ const TimelineSmall = ({ chapter }: { chapter: Chapter }) => {
       <h1
         className={`mb-5 w-full text-left text-4xl font-bold text-white md:text-5xl`}
       >
-        <div className="flex flex-wrap items-center justify-center gap-2">
+        <div className="flex md:flex-wrap items-center justify-center gap-4 md:gap-2">
           <Link
             to={'/courses/$courseId'}
             params={{ courseId: chapter.course.id }}
@@ -147,7 +147,7 @@ const TimelineSmall = ({ chapter }: { chapter: Chapter }) => {
             to={'/courses/$courseId'}
             params={{ courseId: chapter.course.id }}
           >
-            <h1 className="mb-1 mr-2 text-xl font-semibold text-black">
+            <h1 className="mb-1 md:mr-2 text-xl font-semibold text-black max-md:text-center">
               {chapter.course.name}
             </h1>
           </Link>

--- a/apps/web/src/routes/_content/resources/-components/GlossaryFilterBar/index.tsx
+++ b/apps/web/src/routes/_content/resources/-components/GlossaryFilterBar/index.tsx
@@ -42,7 +42,7 @@ export const GlossaryFilterBar = ({
               {t('glossary.needHelp')}
             </p>
             <label
-              className="mb-10 text-white text-xl md:text-[40px] leading-[171%] md:leading-[116%] -tracking-[0.77px] text-center font-normal"
+              className="mb-4 md:mb-10 text-white text-xl md:text-[40px] leading-[171%] md:leading-[116%] -tracking-[0.77px] text-center font-normal"
               htmlFor="glossaryInput"
             >
               {t('glossary.filterBar')}
@@ -54,6 +54,17 @@ export const GlossaryFilterBar = ({
         <input
           type="text"
           value={value}
+          onClick={() => {
+            const element = document.querySelector('#glossaryInput');
+            if (element) {
+              const elementPosition =
+                element.getBoundingClientRect().top + window.scrollY;
+              window.scrollTo({
+                top: elementPosition - 130,
+                behavior: 'smooth',
+              });
+            }
+          }}
           onChange={(event) => {
             onChange(event.target.value);
           }}
@@ -68,21 +79,21 @@ export const GlossaryFilterBar = ({
           }
           id="glossaryInput"
         />
-        {isOnWordPage && (
-          <Link
-            to={'/resources/word/$wordId'}
-            params={{ wordId: randomWord || '' }}
+
+        <Link
+          to={'/resources/word/$wordId'}
+          params={{ wordId: randomWord || '' }}
+          className="max-md:flex justify-center max-md:w-full max-md:mt-2 shrink-0"
+        >
+          <Button
+            variant="newTertiary"
+            size={window.innerWidth >= 768 ? 'm' : 's'}
+            iconLeft={<RxReload />}
+            className="shrink-0"
           >
-            <Button
-              variant="newTertiary"
-              size="m"
-              iconLeft={<RxReload />}
-              className="shrink-0"
-            >
-              {t('glossary.randomSearch')}
-            </Button>
-          </Link>
-        )}
+            {t('glossary.randomSearch')}
+          </Button>
+        </Link>
       </div>
     </div>
   );

--- a/apps/web/src/routes/_content/resources/-components/GlossaryList/index.tsx
+++ b/apps/web/src/routes/_content/resources/-components/GlossaryList/index.tsx
@@ -21,7 +21,7 @@ export const GlossaryList = ({
   const [filteredTerms, setFilteredTerms] =
     useState<JoinedGlossaryWord[]>(glossaryTerms);
 
-  const [maxWords, setMaxWords] = useState(10);
+  const [maxWords, setMaxWords] = useState(20);
 
   useEffect(() => {
     setFilteredTerms(
@@ -42,11 +42,11 @@ export const GlossaryList = ({
             )
             .sort((a, b) => a.term.localeCompare(b.term)),
     );
-    setMaxWords(10);
+    setMaxWords(20);
   }, [selectedLetter, searchTerm, glossaryTerms]);
 
   return (
-    <div className="flex flex-col mx-auto md:mt-20 w-full">
+    <div className="flex flex-col mx-auto md:mt-20 max-w-[840px]">
       {/* Desktop */}
       <section className="flex flex-col w-full gap-6 max-md:hidden">
         <div className="flex max-w-[820px] w-full gap-5 mx-auto px-4">
@@ -103,7 +103,7 @@ export const GlossaryList = ({
           variant="newSecondary"
           size="m"
           className="mx-auto mt-5"
-          onClick={() => setMaxWords((v) => v + 10)}
+          onClick={() => setMaxWords((v) => v + 20)}
         >
           {t('glossary.loadMoreWords')}
         </Button>

--- a/apps/web/src/routes/_content/resources/-other/layout.tsx
+++ b/apps/web/src/routes/_content/resources/-other/layout.tsx
@@ -72,6 +72,7 @@ export const ResourceLayout = ({
               link={link ? link : ''}
               hasGithubDescription={true}
               hideOnMobile={hidePageHeaderMobile}
+              increaseHorizontalPadding={maxWidth === '1360'}
             />
           )}
 

--- a/apps/web/src/routes/_content/resources/book.$bookId.tsx
+++ b/apps/web/src/routes/_content/resources/book.$bookId.tsx
@@ -62,6 +62,7 @@ function Book() {
       tagLine={t('book.pageSubtitle')}
       link={'/resources/books'}
       activeCategory="books"
+      showPageHeader={false}
       backToCategoryButton
     >
       {!isFetched && <Spinner className="size-24 md:size-32 mx-auto" />}

--- a/apps/web/src/routes/_content/resources/builder.$builderId.tsx
+++ b/apps/web/src/routes/_content/resources/builder.$builderId.tsx
@@ -81,6 +81,7 @@ function Builder() {
       tagLine={t('builders.pageSubtitle')}
       link={'/resources/builders'}
       activeCategory="builders"
+      showPageHeader={false}
       backToCategoryButton
     >
       {!isFetched && <Spinner className="size-24 md:size-32 mx-auto" />}
@@ -193,7 +194,7 @@ function Builder() {
               )}
             </div>
           </section>
-          <p className="mobile-body2 md:desktop-h8 whitespace-pre-line text-white p-2.5 md:p-5">
+          <p className="mobile-body2 md:desktop-h8 whitespace-pre-line text-white p-2.5 md:p-5 break-words">
             {builder.description}
           </p>
         </article>

--- a/apps/web/src/routes/_content/resources/glossary.tsx
+++ b/apps/web/src/routes/_content/resources/glossary.tsx
@@ -24,6 +24,14 @@ function Glossary() {
       language: i18n.language ?? 'en',
     });
 
+  const getRandomWord = () => {
+    if (glossaryWords && glossaryWords.length > 0) {
+      return glossaryWords[Math.floor(Math.random() * glossaryWords.length)]
+        .fileName;
+    }
+    return '';
+  };
+
   const handleLetterSelection = (letter: string) => {
     setSelectedLetter(letter === selectedLetter ? null : letter);
   };
@@ -38,7 +46,11 @@ function Glossary() {
       {!isFetched && <Spinner className="size-24 md:size-32 mx-auto" />}
       {isFetched && (
         <div className="flex items-center flex-col px-4">
-          <GlossaryFilterBar onChange={setSearchTerm} value={searchTerm} />
+          <GlossaryFilterBar
+            onChange={setSearchTerm}
+            value={searchTerm}
+            randomWord={getRandomWord()}
+          />
           <AlphabetGlossary
             onLetterSelect={handleLetterSelection}
             selectedLetter={selectedLetter}

--- a/apps/web/src/routes/_content/resources/glossary.tsx
+++ b/apps/web/src/routes/_content/resources/glossary.tsx
@@ -55,12 +55,24 @@ function Glossary() {
             onLetterSelect={handleLetterSelection}
             selectedLetter={selectedLetter}
           />
-          {glossaryWords && (
+          {glossaryWords && glossaryWords.length > 0 && (
             <GlossaryList
               glossaryTerms={glossaryWords}
               selectedLetter={selectedLetter}
               searchTerm={searchTerm}
             />
+          )}
+          {glossaryWords && glossaryWords.length === 0 && (
+            <p className="text-center mt-10 text-white max-w-2xl mobile-body2 md:desktop-body1 whitespace-pre-line">
+              {t('glossary.notTranslated')}{' '}
+              <a
+                className="underline underline-offset-2 hover:text-darkOrange-5"
+                href="https://github.com/PlanB-Network/bitcoin-educational-content"
+              >
+                {t('underConstruction.github')}
+              </a>
+              .
+            </p>
           )}
         </div>
       )}

--- a/apps/web/src/routes/_content/resources/podcast.$podcastId.tsx
+++ b/apps/web/src/routes/_content/resources/podcast.$podcastId.tsx
@@ -55,6 +55,7 @@ function Podcast() {
       tagLine={t('podcasts.pageSubtitle')}
       link={'/resources/podcasts'}
       activeCategory="podcasts"
+      showPageHeader={false}
       backToCategoryButton
     >
       {!isFetched && <Spinner className="size-24 md:size-32 mx-auto" />}

--- a/apps/web/src/routes/_content/resources/word.$wordId.tsx
+++ b/apps/web/src/routes/_content/resources/word.$wordId.tsx
@@ -75,7 +75,10 @@ function GlossaryWord() {
     <ResourceLayout
       title={t('glossary.pageTitle')}
       tagLine={t('glossary.pageSubtitle')}
+      link={'/resources/glossary'}
       activeCategory="glossary"
+      showPageHeader={false}
+      backToCategoryButton
     >
       {!isFetched && <Spinner className="size-24 md:size-32 mx-auto" />}
       {isFetched && (


### PR DESCRIPTION
### Fixes Glossary
- Increase to 20 terms instead of 10
- Reduce the size of the bar just before the term and end definition on desktop
- Increase paragraph spacing in markdown
- Mobile: Auto-scroll search bar to avoid hidden words
- Mobile: Reduce size and top spacing of random search
- Add random search button (small on mobile) on the main page + reduce spacing between title & search bar on mobile
- Glossary on mobile: when viewing a word, change the category panel to match the others resources individual pages

### Fixes Resources
- Remove "all this data is managed" when viewing specific resources (e.g., individual word), similar to the conference page
- Fix max width of "all this data" text on mobile, example: conference/books at 411px width
- Fix description overflow issue in Pleblab builder (check Telegram for details)

### Fixes Courses
- Display course title on the same line on mobile
- Fix issue with quote block not rendering properly (hyperlinks, special cases, etc.)
