### PR TITLE
fix(build): removed sourcemap errors

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -26,6 +26,16 @@ export default defineConfig({
     chunkSizeWarningLimit: 600,
     cssCodeSplit: true,
     outDir: 'dist',
+    sourcemap: true,
+    rollupOptions: {
+      onwarn(warning, defaultHandler) {
+        if (warning.code === 'SOURCEMAP_ERROR') {
+          return;
+        }
+
+        defaultHandler(warning);
+      },
+    },
   },
 
   assetsInclude: [UI_PACKAGE_ASSETS],


### PR DESCRIPTION
So this errors are most likely caused because of issues with rollUp that are not yet officially fixed. There are 2 possible solutions from what I have found first one is to silence the errors until fix is made (what I have done here) https://github.com/vitejs/vite/issues/15012 and second one is to use plugin some people are recommending it https://github.com/huozhi/rollup-preserve-directives
Issue arise when people use something like (shadcn, materialUI etc...).