### PR TITLE
Fix exam timestamps validation process

### DIFF
--- a/apps/api/src/services/cron/index.ts
+++ b/apps/api/src/services/cron/index.ts
@@ -12,6 +12,7 @@ export const registerCronTasks = async (ctx: Dependencies) => {
     ctx.crons.addTask('5m', () => refreshCoursesRatings());
     ctx.crons.addTask('5m', () => timestampService.timestampAllExams());
     ctx.crons.addTask('5m', () => timestampService.upgradeAllTimeStamps());
+    ctx.crons.addTask('5m', () => timestampService.validateAllTimeStamps());
     ctx.crons.addTask('5m', () => timestampService.generateAllCertificates());
     ctx.crons.addTask('5m', () => timestampService.generateAllThumbnails());
   }


### PR DESCRIPTION
Fix ots validation process: it currently marks timestamps as validated if an OTS upgrade has been performed during the current loop; but if the upgrade is performed "too soon" the ots file is never checked again for validation.  