### PR TITLE
Update Discord invite link with auto-role assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the repository for the Plan B Network websites. The goal of this project
 
 The repository holding the data for this project is [here](https://github.com/PlanB-Network/bitcoin-educational-content).
 
-We are looking for contributors! If you want to help or learn more about the project, please reach out to us on [X/Twitter](https://x.com/planb_network) or [Discord](https://discord.com/invite/CHvZAhJCBh).
+We are looking for contributors! If you want to help or learn more about the project, please reach out to us on [X/Twitter](https://x.com/planb_network) or [Discord](https://discord.gg/8wuekdsHp5).
 
 ## Development - Run the project locally
 

--- a/apps/academy/src/components/footer.tsx
+++ b/apps/academy/src/components/footer.tsx
@@ -45,7 +45,7 @@ const SOCIAL_LINKS = [
     label: 'Linkedin',
   },
   {
-    href: 'https://discord.gg/q9CFPmRNAD',
+    href: 'https://discord.gg/8wuekdsHp5',
     icon: BsDiscord,
     isReactIcon: true,
     label: 'Discord',

--- a/apps/network/src/components/footer.tsx
+++ b/apps/network/src/components/footer.tsx
@@ -34,7 +34,7 @@ const SOCIAL_LINKS = [
     label: 'Linkedin',
   },
   {
-    href: 'https://discord.gg/q9CFPmRNAD',
+    href: 'https://discord.gg/8wuekdsHp5',
     icon: TbBrandDiscordFilled,
     isReactIcon: true,
     label: 'Discord',


### PR DESCRIPTION
## Summary

- Replace all outdated Discord invite links with the new one (`discord.gg/8wuekdsHp5`)
- Updated in: `README.md`, academy footer, and network footer
- This new invite link automatically assigns the **Plan ₿ Student** role to anyone who joins through it

## Test plan

- [x] Verify Discord links in academy and network footers point to the new invite
- [x] Confirm joining via the link grants the Plan ₿ Student role on Discord