### PR TITLE
Increase exam question duration from 45s to 60s

### DIFF
--- a/apps/academy/src/utils/courses.ts
+++ b/apps/academy/src/utils/courses.ts
@@ -9,7 +9,7 @@ export function addSpaceToCourseIndex(courseIndex?: string | null) {
 }
 
 export const MULTI_ATTEMPT_EXAM_QUESTION_NUMBER = 40;
-export const EXAM_QUESTION_DURATION_SECONDS = 45;
+export const EXAM_QUESTION_DURATION_SECONDS = 60;
 
 export const goToChapterParameters = (
   chapter: CourseChapterResponse,


### PR DESCRIPTION
## Problem
Non-native English speakers struggle with the current 45-second time limit per exam question, as they need extra time to read and understand the questions in a foreign language.

## Solution
Increase the exam question duration from 45 to 60 seconds, giving all students more time to process each question without rushing.

## Test plan
- [ ] Verify exam presentation pages show correct total duration (e.g. 20 questions = 20 minutes)
- [ ] Verify countdown timer during exam session uses the new 60s/question value