### PR TITLE
fix: incorrect exam duration in teacher view

### DIFF
--- a/apps/academy/src/routes/$lang/dashboard/professor/-components/exam-results.tsx
+++ b/apps/academy/src/routes/$lang/dashboard/professor/-components/exam-results.tsx
@@ -25,13 +25,13 @@ import {
   TbWeight,
 } from 'react-icons/tb';
 
+import { EXAM_QUESTION_DURATION_SECONDS } from '#src/utils/courses.ts';
 import { formatDateRange } from '#src/utils/date.ts';
 import { trpc } from '#src/utils/trpc.ts';
 
 export const SELF_PACED_PASSING_THRESHOLD = 80;
 const DEFAULT_ASSIGNMENT_WEIGHT = 40;
 const MAX_QUESTIONS_IN_MULTI_ATTEMPT_EXAM = 40;
-const DURATION_CALCULATION_QUESTIONS_PER_MINUTE = 2;
 const TWO_HOURS_IN_MS = 2 * 60 * 60 * 1000;
 const WEIGHT_PER_BAR = 20;
 const TOTAL_WEIGHT_BARS = 5;
@@ -434,9 +434,7 @@ const ExamCard = ({
 
   const averageDuration = calculateAverageDuration(
     examGrades,
-    Math.round(
-      questionsInExam * (60 / DURATION_CALCULATION_QUESTIONS_PER_MINUTE),
-    ),
+    Math.round(questionsInExam * EXAM_QUESTION_DURATION_SECONDS),
   );
 
   if (!isExamInfoFetched && type === 'single-trial') {
@@ -525,7 +523,7 @@ const ExamCard = ({
             {questionsInExam > 0 && (
               <InfoRow
                 label={t('words.duration')}
-                value={`${Math.round(questionsInExam / DURATION_CALCULATION_QUESTIONS_PER_MINUTE)}'`}
+                value={`${Math.round((questionsInExam * EXAM_QUESTION_DURATION_SECONDS) / 60)}'`}
                 icon={<TbClock className="size-6 shrink-0" />}
                 showBorder={type !== 'multi-attempts'}
               />
@@ -778,9 +776,7 @@ const downloadExamGrades = async (
               new Date(grade.startedAt).getTime()) /
               1000,
           ),
-          Math.round(
-            (totalQuestions * 60) / DURATION_CALCULATION_QUESTIONS_PER_MINUTE,
-          ),
+          Math.round(totalQuestions * EXAM_QUESTION_DURATION_SECONDS),
         );
       }
 


### PR DESCRIPTION
## Problem

After PR #1964 increased exam question duration from 45s to 60s (`EXAM_QUESTION_DURATION_SECONDS` in `utils/courses.ts`), the **teacher exam results view** still displayed incorrect durations (e.g. 20 questions → 10' instead of 20', 60 questions → 30' instead of 60').

This is because `exam-results.tsx` used its own local constant `DURATION_CALCULATION_QUESTIONS_PER_MINUTE = 2` (equivalent to 30s/question) instead of the shared `EXAM_QUESTION_DURATION_SECONDS`. The student-facing views correctly imported the shared constant and showed the right values.

## Solution

- Remove the local `DURATION_CALCULATION_QUESTIONS_PER_MINUTE` constant
- Import `EXAM_QUESTION_DURATION_SECONDS` from `#src/utils/courses.ts` (single source of truth)
- Update the 3 usages: duration display, average duration cap, and Excel export duration cap

## Impact

- Duration shown to professors now matches the student view
- Duration caps for average calculation and Excel export use the correct value
- Any future change to `EXAM_QUESTION_DURATION_SECONDS` will automatically propagate to both views