### PR TITLE
fix: Nominatim location sync — User-Agent policy

### DIFF
--- a/packages/service-content/src/lib/events/services/events-locations.sync.ts
+++ b/packages/service-content/src/lib/events/services/events-locations.sync.ts
@@ -23,13 +23,25 @@ const expectedResponseSchema = z.array(
     })),
 );
 
+const NOMINATIM_DELAY_MS = 1100; // Nominatim policy: max 1 req/s
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
 const fetchEventLocation = async (query: string) => {
   const q = encodeURIComponent(query);
 
   const res = await fetch(
     `https://nominatim.openstreetmap.org/search?format=jsonv2&limit=1&q=${q}`,
+    {
+      headers: {
+        'User-Agent': 'PlanBNetwork/1.0 (https://planb.network)',
+      },
+    },
   );
-  console.log('Searching location for project:', query);
+
+  if (!res.ok) {
+    throw new Error(`Nominatim HTTP ${res.status} for "${query}"`);
+  }
 
   const data = await res.json();
   return expectedResponseSchema.parse(data)?.[0];
@@ -43,6 +55,7 @@ export const createSyncEventsLocations = ({
       const locations = await postgres.exec(getEventsWithoutLocationQuery());
 
       for (const { name } of locations) {
+        await sleep(NOMINATIM_DELAY_MS);
         const result = await fetchEventLocation(name).catch(() => null);
         if (!result) {
           const warn = `[sync] Could not find event location ${name}`;

--- a/packages/service-content/src/lib/resources/services/projects-locations.sync.ts
+++ b/packages/service-content/src/lib/resources/services/projects-locations.sync.ts
@@ -23,13 +23,25 @@ const expectedResponseSchema = z.array(
     })),
 );
 
+const NOMINATIM_DELAY_MS = 1100; // Nominatim policy: max 1 req/s
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
 const fetchProjectLocation = async (query: string) => {
   const q = encodeURIComponent(query);
 
   const res = await fetch(
     `https://nominatim.openstreetmap.org/search?format=jsonv2&limit=1&q=${q}`,
+    {
+      headers: {
+        'User-Agent': 'PlanBNetwork/1.0 (https://planb.network)',
+      },
+    },
   );
-  console.log('Searching location for event:', query);
+
+  if (!res.ok) {
+    throw new Error(`Nominatim HTTP ${res.status} for "${query}"`);
+  }
 
   const data = await res.json();
   return expectedResponseSchema.parse(data)?.[0];
@@ -43,6 +55,7 @@ export const createSyncProjectsLocations = ({
       const locations = await postgres.exec(getProjectsWithoutLocationQuery());
 
       for (const { name } of locations) {
+        await sleep(NOMINATIM_DELAY_MS);
         const result = await fetchProjectLocation(name).catch(() => null);
         if (!result) {
           const warn = `[sync] Could not find project location: ${name}`;


### PR DESCRIPTION
## Problem

Event/project location sync fails silently for new locations. The `.catch(() => null)` swallowed all errors, making diagnosis impossible.

**Root cause identified**: Nominatim returns **HTTP 429** (rate limit) with an HTML error page instead of JSON. The code calls `res.json()` on this HTML, crashing with `SyntaxError: Unexpected token '<'`. This happens because requests were fired in a tight loop with no delay, violating Nominatim's 1 req/s policy.

## Solution

1. **1.1s delay between requests** — respects Nominatim's max 1 req/s rate limit
2. **User-Agent header** — required by Nominatim usage policy (requests without it get 403)
3. **HTTP status check** (`res.ok`) — throws a clear error on non-200 responses instead of crashing on HTML parsing

## Tested locally

Ran a full content sync against the public Nominatim API with the fix applied:
- **186 event locations** resolved successfully
- **21 project locations** resolved successfully
- **Zero 429 errors** with the 1.1s delay
- Confirmed that without the delay, requests get rate-limited after ~15-20 requests
