### PR TITLE
fix: display timezone (UTC+X) on exam and event pages

### DIFF
--- a/apps/academy/src/routes/$lang/_course/courses/$courseSlug/-components/single-trial-exam/single-trial-exam-presentation.tsx
+++ b/apps/academy/src/routes/$lang/_course/courses/$courseSlug/-components/single-trial-exam/single-trial-exam-presentation.tsx
@@ -18,7 +18,7 @@ import { useDisclosure } from '#src/hooks/use-disclosure.ts';
 import { AppContext } from '#src/providers/context.tsx';
 import { ChangeDisplayNameModal } from '#src/routes/$lang/dashboard/-components/change-display-name-modal.tsx';
 import { EXAM_QUESTION_DURATION_SECONDS } from '#src/utils/courses.ts';
-import { formatTimeRange } from '#src/utils/date.ts';
+import { formatTimeRange, getUTCOffset } from '#src/utils/date.ts';
 import { trpc } from '#src/utils/trpc.ts';
 import { ChangeDisplayName } from '../shared-between-exams/change-display-name.tsx';
 
@@ -94,11 +94,13 @@ export const SingleTrialExamPresentation = ({
               <Trans
                 i18nKey={'courses.exam.singleAttemptAvailability'}
                 values={{
-                  date: formatTimeRange(
-                    chapter.startDate!,
-                    chapter.endDate!,
-                    chapter.timezone ?? 'CET',
-                  ),
+                  date: chapter.timezone
+                    ? `${formatTimeRange(
+                        chapter.startDate!,
+                        chapter.endDate!,
+                        chapter.timezone,
+                      )} (${getUTCOffset(chapter.timezone)})`
+                    : formatTimeRange(chapter.startDate!, chapter.endDate!),
                 }}
               />
             </p>

--- a/apps/academy/src/routes/$lang/events/$eventId.tsx
+++ b/apps/academy/src/routes/$lang/events/$eventId.tsx
@@ -27,7 +27,11 @@ import { useSmaller } from '#src/hooks/use-smaller.ts';
 import { AppContext } from '#src/providers/context.tsx';
 import { ConversionRateContext } from '#src/providers/conversionRateContext.tsx';
 import type { PaymentModalDataModel } from '#src/services/utils.tsx';
-import { formatDateRange, formatTimeRange } from '#src/utils/date.ts';
+import {
+  formatDateRange,
+  formatTimeRange,
+  getUTCOffset,
+} from '#src/utils/date.ts';
 import { resourceImgUrl } from '#src/utils/index.ts';
 import { base64ToBlob } from '#src/utils/misc.ts';
 import { trpc } from '#src/utils/trpc.js';
@@ -158,13 +162,21 @@ function EventDetails() {
     );
   const timeString =
     event &&
-    formatTimeRange(
-      event.startDate,
-      event.endDate,
-      event.timezone ?? undefined,
-      undefined,
-      true,
-    );
+    (event.timezone
+      ? `${formatTimeRange(
+          event.startDate,
+          event.endDate,
+          event.timezone,
+          undefined,
+          true,
+        )} (${getUTCOffset(event.timezone)})`
+      : formatTimeRange(
+          event.startDate,
+          event.endDate,
+          undefined,
+          undefined,
+          true,
+        ));
 
   const EventButtons = () => {
     if (!event) return null;


### PR DESCRIPTION
## Problem

On the single trial exam page and the event detail page, date/time ranges are displayed **without any timezone indicator**. Users see dates like "20 mars 2026 à 16:00 – 25 mars 2026 à 15:00" with no way to know which timezone this refers to.

Meanwhile, the global certifications page correctly appends the timezone in parentheses — e.g. `(UTC+1)`.

Additionally, the single trial exam page had a hardcoded `'CET'` fallback when no timezone was set, which is incorrect since CET is not a valid IANA timezone identifier.

## Solution

- Use the existing `getUTCOffset()` utility to append `(UTC+X)` in parentheses to the formatted time string — **only when a timezone is configured** on the chapter/event.
- When no timezone is set, display the date without any offset indicator (no more hardcoded `'CET'` fallback), making it obvious during QA that the timezone is missing in the content.
- This matches the pattern already used in `global-certifications.tsx`.

### Files changed

| File | Change |
|------|--------|
| `single-trial-exam-presentation.tsx` | Append `(UTC+X)` to exam date range when `chapter.timezone` exists; remove `'CET'` fallback |
| `$eventId.tsx` | Append `(UTC+X)` to event time range when `event.timezone` exists |

## Test plan

- [ ] Open a single trial exam page with a timezone set → verify `(UTC+X)` appears in the availability text
- [ ] Open a single trial exam page without timezone set → verify date shows without offset
- [ ] Open an event detail page with timezone → verify `(UTC+X)` appears next to the time
- [ ] Open an event detail page without timezone → verify time shows without offset