### PR TITLE
fix: update time for selection and affection cron

### DIFF
--- a/apps/academy/src/routes/$lang/_course/courses/$courseSlug/_$courseSlug/assignment.tsx
+++ b/apps/academy/src/routes/$lang/_course/courses/$courseSlug/_$courseSlug/assignment.tsx
@@ -153,7 +153,7 @@ function Assignment() {
 
   const openAssignmentDate = new Date(
     isTestnetOrDevelopmentEnvironment()
-      ? '2026-03-20T15:00:00Z'
+      ? '2026-03-23T13:00:00Z'
       : courseInfo?.assignmentStartDate || '2026-03-27T14:00:00Z',
   ).getTime();
   const endAssignmentDate = new Date(

--- a/apps/api/src/services/cron/index.ts
+++ b/apps/api/src/services/cron/index.ts
@@ -548,7 +548,7 @@ export const registerCronTasks = async (ctx: Dependencies) => {
   // TESTNET ONLY
   if (process.env.NODE_ENV === 'testnet') {
     // PLAN B PROGRAM JOB
-    ctx.crons.addTask('mar20_13_gmt', async () => {
+    ctx.crons.addTask('mar23_12_gmt', async () => {
       console.log('[cron] Running selectBizSchoolStudentsForAssignments job');
 
       const selectBizSchoolStudentsForAssignments =
@@ -561,7 +561,7 @@ export const registerCronTasks = async (ctx: Dependencies) => {
     });
 
     // PLAN B PROGRAM JOB
-    ctx.crons.addTask('mar23_11_gmt', async () => {
+    ctx.crons.addTask('mar24_10_gmt', async () => {
       console.log('[cron] Running affectProjectToBizSchoolStudents job');
 
       const affectProjectToBizSchoolStudents =

--- a/packages/cron/src/index.ts
+++ b/packages/cron/src/index.ts
@@ -9,8 +9,8 @@ export type Frequency =
   | '1day'
   | '1month'
   | 'sun4pm'
-  | 'mar20_13_gmt'
-  | 'mar23_11_gmt'
+  | 'mar23_12_gmt'
+  | 'mar24_10_gmt'
   | 'mar25_15_gmt'
   | 'mar31_12_gmt'
   | 'daily_8_gmt'
@@ -51,16 +51,16 @@ export const createCronService = () => {
   crons.set('1month', new CronJob('0 0 1 * *', createExecTasks('1month')));
   crons.set('sun4pm', new CronJob('0 16 * * 0', createExecTasks('sun4pm')));
   crons.set(
-    'mar20_13_gmt',
-    new CronJob('0 13 20 3 *', createExecTasks('mar20_13_gmt')),
+    'mar23_12_gmt',
+    new CronJob('0 12 23 3 *', createExecTasks('mar23_12_gmt')),
   );
   crons.set(
     'mar25_15_gmt',
     new CronJob('0 15 25 3 *', createExecTasks('mar25_15_gmt')),
   );
   crons.set(
-    'mar23_11_gmt',
-    new CronJob('0 11 23 3 *', createExecTasks('mar23_11_gmt')),
+    'mar24_10_gmt',
+    new CronJob('0 10 24 3 *', createExecTasks('mar24_10_gmt')),
   );
   crons.set(
     'mar31_12_gmt',


### PR DESCRIPTION
Because yesterday the selection cron did not work, we have updated the date for both cron (selection and affection) and the assignment opening for testnet env. 


