### PR TITLE
fix: update constant for assginment selection and affection

### DIFF
--- a/apps/api/src/routers/rest/planb-program.ts
+++ b/apps/api/src/routers/rest/planb-program.ts
@@ -31,8 +31,8 @@ export const createRestPlanbProgramRoutes = (
         const selectBizSchoolStudentsForAssignments =
           createSelectBizSchoolStudentsForAssignments(dependencies);
 
-        await selectBizSchoolStudentsForAssignments(bizSchoolCourseId, 75);
-        await selectBizSchoolStudentsForAssignments(devSchoolCourseId, 75);
+        await selectBizSchoolStudentsForAssignments(bizSchoolCourseId, 91);
+        await selectBizSchoolStudentsForAssignments(devSchoolCourseId, 48);
 
         console.log('[api] Finished selectBizSchoolStudentsForAssignments job');
 
@@ -54,8 +54,8 @@ export const createRestPlanbProgramRoutes = (
         const affectProjectToBizSchoolStudents =
           createAffectProjectToBizSchoolStudents(dependencies);
 
-        await affectProjectToBizSchoolStudents(bizSchoolCourseId, 1);
-        await affectProjectToBizSchoolStudents(devSchoolCourseId, 2);
+        await affectProjectToBizSchoolStudents(bizSchoolCourseId, 7);
+        await affectProjectToBizSchoolStudents(devSchoolCourseId, 8);
 
         console.log('[api] Finished affectProjectToBizSchoolStudents job');
 


### PR DESCRIPTION
With @mumacadam, we have update the constant for assignment selection and affection to reflect the threshold for Business and Developer Track:
- for business track: 91 students, with 7 students per assignment
- for developer track: 48 students, with 8 students per assignment