### PR TITLE
fix: prevent assignment ranking preferences from resetting

### DIFF
--- a/apps/academy/src/routes/$lang/_course/courses/$courseSlug/_$courseSlug.tsx
+++ b/apps/academy/src/routes/$lang/_course/courses/$courseSlug/_$courseSlug.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 import { useContext, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -22,7 +22,7 @@ function CourseLayout() {
   const { data: course } = useQuery(
     trpc.content.getCourse.queryOptions(
       { id: courseSlug, language: i18n.language },
-      { staleTime: 300_000 },
+      { staleTime: 300_000, placeholderData: keepPreviousData },
     ),
   );
 

--- a/apps/academy/src/routes/$lang/_course/courses/$courseSlug/_$courseSlug/assignment.tsx
+++ b/apps/academy/src/routes/$lang/_course/courses/$courseSlug/_$courseSlug/assignment.tsx
@@ -99,6 +99,8 @@ function Assignment() {
     CourseAssignment[]
   >([]);
 
+  const RANKING_DRAFT_KEY = `ranking-draft-${courseId}`;
+
   const {
     data: userProgress,
     refetch: refetchUserProgress,
@@ -213,6 +215,7 @@ function Assignment() {
   };
 
   const handleSaveList = () => {
+    localStorage.removeItem(RANKING_DRAFT_KEY);
     saveAssignments.mutate({
       assignmentsIds: assignmentsOrdered.map((assignment) => assignment.id),
       courseId,
@@ -315,11 +318,49 @@ function Assignment() {
     }
   };
 
+  const RANKING_DRAFT_TTL = 14 * 24 * 60 * 60 * 1000; // 14 days
+
   useEffect(() => {
     if (assignments && assignmentsOrdered.length === 0) {
+      const saved = localStorage.getItem(RANKING_DRAFT_KEY);
+      if (saved) {
+        try {
+          const { ids: savedIds, timestamp } = JSON.parse(saved) as {
+            ids: string[];
+            timestamp: number;
+          };
+          if (Date.now() - timestamp < RANKING_DRAFT_TTL) {
+            const serverIds = assignments.map((a) => a.id);
+            if (
+              savedIds.length === serverIds.length &&
+              savedIds.every((id) => serverIds.includes(id))
+            ) {
+              setAssignmentsOrdered(
+                savedIds.map((id) => assignments.find((a) => a.id === id)!),
+              );
+              return;
+            }
+          }
+        } catch {
+          // ignore malformed data
+        }
+        localStorage.removeItem(RANKING_DRAFT_KEY);
+      }
       setAssignmentsOrdered(assignments);
     }
-  }, [assignments, assignmentsOrdered.length]);
+  }, [assignments, assignmentsOrdered.length, RANKING_DRAFT_KEY]);
+
+  useEffect(() => {
+    if (assignmentsOrdered.length > 0 && canRankAssignments) {
+      localStorage.setItem(
+        RANKING_DRAFT_KEY,
+        JSON.stringify({
+          ids: assignmentsOrdered.map((a) => a.id),
+          timestamp: Date.now(),
+        }),
+      );
+    }
+  }, [assignmentsOrdered, canRankAssignments, RANKING_DRAFT_KEY]);
 
   if (!courseInfo) {
     return <Loader />;

--- a/apps/academy/src/routes/$lang/_course/courses/$courseSlug/_$courseSlug/assignment.tsx
+++ b/apps/academy/src/routes/$lang/_course/courses/$courseSlug/_$courseSlug/assignment.tsx
@@ -316,10 +316,10 @@ function Assignment() {
   };
 
   useEffect(() => {
-    if (assignments) {
+    if (assignments && assignmentsOrdered.length === 0) {
       setAssignmentsOrdered(assignments);
     }
-  }, [assignments]);
+  }, [assignments, assignmentsOrdered.length]);
 
   if (!courseInfo) {
     return <Loader />;


### PR DESCRIPTION
## Problem

Students ranking their assignment preferences via drag-and-drop lose their ordering after approximately 5 minutes. Because preference submission is irrevocable, users cannot safely click Save after a reset — they must re-rank from scratch.

**Root cause**: three independent vectors reset component state.

1. **Unguarded `useEffect`** in `assignment.tsx` — unconditionally overwrites `assignmentsOrdered` on every query refetch. With `staleTime: 60s` and `refetchOnWindowFocus: true` (default), any tab switch after 60s wipes the user's ordering.

2. **Guillotine pattern** in `_$courseSlug.tsx` — `if (!course) return null` unmounts the entire `<Outlet />` subtree when the `getCourse` query key changes (e.g. language switch), destroying all local state in child components.

3. **No draft persistence** — ranking is stored only in React `useState`, so any page refresh, navigation, or session change loses the user's work-in-progress.

## Solution

**Commit 1** — Guard the `useEffect` to only initialize `assignmentsOrdered` when the array is empty (first mount). Subsequent refetches no longer overwrite user ordering.

**Commit 2** — Add `placeholderData: keepPreviousData` to the `getCourse` query in `CourseLayout`. During query key transitions, React Query retains previous data instead of returning `undefined`, preventing the subtree unmount.

**Commit 3** — Persist ranking draft to `localStorage` keyed by courseId. Restores on page load after validating IDs against server data. 14-day TTL auto-expires stale drafts. Cleared on successful save submission.

## Tested

- Local dev environment on `dev` branch: ranking resets on page refresh (bug confirmed)
- Local dev environment on fix branch: ranking persists across page refresh, window focus changes, and logout/login cycles
