### PR TITLE
feat: enhance local-dev with PR review & MinIO S3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,11 +41,14 @@ SENDGRID_KEY=
 SENDGRID_EMAIL=
 
 # S3
-S3_ENDPOINT=https://127.0.0.1
-S3_BUCKET=none
-S3_ACCESS_KEY=none
-S3_SECRET_KEY=none
-S3_REGION=none
+# For local dev (docker compose): the minio service works out of the box with
+# these values. forcePathStyle is required for MinIO / self-hosted S3.
+S3_ENDPOINT=http://minio:9000
+S3_BUCKET=blms-local
+S3_ACCESS_KEY=minioadmin
+S3_SECRET_KEY=minioadmin
+S3_REGION=us-east-1
+S3_FORCE_PATH_STYLE=true
 
 # Vector (optional: if including compose.logs.yml)
 S3_LOG_ENDPOINT=https://127.0.0.1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,78 @@
+# Agent guide — local development & bug reproduction
+
+Read this before touching the local environment. It exists because agents (and
+humans) keep rediscovering the same traps.
+
+## TL;DR
+
+```bash
+./scripts/local-dev.sh up        # start everything (postgres, minio, typesense, cdn, dev servers)
+./scripts/local-dev.sh status    # what's running
+./scripts/local-dev.sh logs --errors
+./scripts/local-dev.sh context --preset career-step3   # seed test user + scenario
+./scripts/local-dev.sh down
+```
+
+- Academy front: http://localhost:8181 — API: http://localhost:3000
+- Test user: `testuser` / `test1234` (created by `context`)
+- Logs (all services, greppable): `/tmp/blms-dev/combined.log`
+
+## Two stacks — pick ONE, never both
+
+| | `scripts/local-dev.sh` (preferred for piloting) | `docker compose up` (README option 1) |
+|---|---|---|
+| Containers | `blms-local-*` | `bitcoin-learning-management-system-*` |
+| Dev servers | on host (pnpm, hot reload) | inside containers |
+| Seeding/presets | built-in (`context`) | manual SQL |
+
+They bind the same ports (5432, 8108, 9000). `local-dev.sh up` refuses to start
+if the compose stack is running. If you hit `port is already allocated`, the
+other stack is up.
+
+Compose caveat: only `apps/*` and a subset of `packages/*/src` are volume-mounted
+into containers — an edit in a non-mounted package silently does nothing until
+you `docker cp` or rebuild. Check the `volumes:` list in `compose.yml`.
+
+## Seeding scenarios (context command)
+
+Never hand-craft SQL for user/profile state — use presets, or extend them
+(`_apply_preset` / `_apply_career_preset` in `scripts/local-dev.sh`):
+
+```bash
+./scripts/local-dev.sh context --list                  # all presets
+./scripts/local-dev.sh context --preset career-step3   # career profile ready for step 4
+./scripts/local-dev.sh context --preset assignment-can-rank --course btc402
+./scripts/local-dev.sh context --set progress_percentage=100 --course btc402
+```
+
+Rules learned the hard way:
+- **Always `gen_random_uuid()`** for ids. zod validates UUIDs strictly (RFC
+  version/variant nibbles); a hand-made `1111...` id passes the DB but makes
+  tRPC output validation fail with an opaque 500 — the UI just shows empty data.
+- Prefer referencing existing rows (e.g. `users.job_titles` is seeded by
+  migrations) over inserting new ones; enums and NOT NULL columns bite.
+- Career portal access is gated on having *bought* a course from
+  `COURSES_CAREER_ACCESS` (`packages/shared/src/utils.ts`) — the `career-*`
+  presets handle that.
+
+## S3 / file uploads
+
+Both stacks provide a local MinIO (`S3_FORCE_PATH_STYLE=true` is required —
+MinIO doesn't support vhost-style buckets). If uploads return 500 with
+`ECONNREFUSED :9000`, MinIO isn't up or `S3_ENDPOINT` points to the wrong host
+(inside compose containers it must be `http://minio:9000`, not `localhost`).
+MinIO console: http://localhost:9001 (minioadmin/minioadmin).
+
+## Misc traps
+
+- First run needs migrations: `pnpm run dev:db:migrate` (compose) — local-dev.sh
+  does it automatically.
+- Content (courses, tutorials) comes from a separate repo, synced via
+  `./scripts/local-dev.sh sync` or `curl -X POST localhost:3000/api/github/sync`.
+  Most piloting works without a full sync; presets create stubs when needed.
+- The API dies at boot if postgres isn't ready and waits for a file change;
+  compose now uses healthcheck-gated `depends_on`, but if you see
+  `ENOTFOUND postgres`, restart the api container.
+- Register endpoint is public: `POST /api/trpc/auth.credentials.register`
+  `{"json":{"username":"...","password":"..."}}` — handy to create extra users
+  with a session from a driven browser.

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -136,6 +136,8 @@ export const s3: S3Config = {
   accessKey: getenv('S3_ACCESS_KEY').trim(),
   bucket: getenv('S3_BUCKET').trim(),
   endpoint: getenv('S3_ENDPOINT').trim(),
+  // Required for MinIO and most self-hosted S3 (no wildcard DNS for vhost-style buckets)
+  forcePathStyle: getenv('S3_FORCE_PATH_STYLE', 'false') === 'true',
   region: getenv('S3_REGION').trim(),
   secretKey: getenv('S3_SECRET_KEY').trim(),
 };

--- a/compose.yml
+++ b/compose.yml
@@ -39,6 +39,33 @@ services:
       <<: *healthcheck
       test: ['CMD', 'nc', '-zv', 'localhost', '5432']
 
+  minio:
+    <<: *defaults
+    image: minio/minio:latest
+    command: server /data --console-address ":9001"
+    ports:
+      - 9000:9000
+      - 9001:9001 # web console
+    environment:
+      MINIO_ROOT_USER: ${S3_ACCESS_KEY:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${S3_SECRET_KEY:-minioadmin}
+    volumes:
+      - minio:/data
+    healthcheck:
+      <<: *healthcheck
+      test: ['CMD', 'mc', 'ready', 'local']
+
+  # One-shot: creates the local bucket then exits
+  minio-init:
+    image: minio/mc:latest
+    restart: 'no'
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      sh -c "mc alias set local http://minio:9000 ${S3_ACCESS_KEY:-minioadmin} ${S3_SECRET_KEY:-minioadmin}
+      && mc mb local/${S3_BUCKET:-blms-local} --ignore-existing"
+
   cdn:
     <<: *defaults
     image: nginx:1.29.1-alpine
@@ -58,6 +85,8 @@ services:
     environment:
       HOST: 0.0.0.0
       POSTGRES_HOST: postgres
+      S3_ENDPOINT: ${S3_ENDPOINT:-http://minio:9000}
+      S3_FORCE_PATH_STYLE: ${S3_FORCE_PATH_STYLE:-true}
       TYPESENSE_NODES: http://typesense:8108
       ONLYOFFICE_URL: ${ONLYOFFICE_URL:-http://localhost:80}
     volumes:
@@ -70,13 +99,18 @@ services:
       - ./packages/schemas/src:/home/node/packages/schemas/src
       - ./packages/types/src:/home/node/packages/types/src
       - ./packages/service-user/src:/home/node/packages/service-user/src
+      - ./packages/s3/src:/home/node/packages/s3/src
       - ./.env:/home/node/.env
       - cdn:$CDN_PATH
       - sync:${SYNC_PATH:-/tmp/sync}
       - ${OTS_PGP_KEY_PATH:-./key.asc}:/tmp/key.asc:ro
     depends_on:
-      - typesense
-      - postgres
+      typesense:
+        condition: service_started
+      postgres:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
     healthcheck:
       <<: *healthcheck
       test: ['CMD', 'nc', '-zv', 'localhost', '3000']
@@ -182,6 +216,7 @@ services:
 
 volumes:
   typesense:
+  minio:
   corestore:
   postgres:
   cdn:

--- a/packages/s3/src/index.ts
+++ b/packages/s3/src/index.ts
@@ -65,6 +65,7 @@ export const createS3Service = (config: S3Config): S3Service => {
       secretAccessKey: config.secretKey,
     },
     endpoint: config.endpoint,
+    forcePathStyle: !config.endpoint.includes('amazonaws.com'),
     region: config.region,
   });
 

--- a/packages/s3/src/index.ts
+++ b/packages/s3/src/index.ts
@@ -65,7 +65,7 @@ export const createS3Service = (config: S3Config): S3Service => {
       secretAccessKey: config.secretKey,
     },
     endpoint: config.endpoint,
-    forcePathStyle: !config.endpoint.includes('amazonaws.com'),
+    forcePathStyle: config.forcePathStyle,
     region: config.region,
   });
 

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -66,6 +66,8 @@ export interface S3Config {
   endpoint: string;
   accessKey: string;
   secretKey: string;
+  /** Path-style addressing (bucket in path, not subdomain) — required for MinIO and most self-hosted S3. */
+  forcePathStyle: boolean;
 }
 
 export interface SwissBitcoinPayConfig {

--- a/scripts/local-dev.sh
+++ b/scripts/local-dev.sh
@@ -16,6 +16,8 @@ set -euo pipefail
 # Branch options (CLI-friendly for agents):
 #   --app <branch>              Switch BLMS application branch
 #   --content <branch>          Switch public content repo branch + sync
+#   --content-pr <number>       Switch to a content PR's branch (handles forks) + sync
+#   --content-reset             Reset content repo to upstream main
 #   --private-content <branch>  Switch private content repo branch + sync
 #
 # Log files (agent-readable):
@@ -28,6 +30,8 @@ set -euo pipefail
 #   ./scripts/local-dev.sh logs --errors
 #   ./scripts/local-dev.sh branch --app fix/assignment-ranking-state-reset
 #   ./scripts/local-dev.sh branch --content dev --private-content main
+#   ./scripts/local-dev.sh branch --content-pr 3777   # review PR from any fork
+#   ./scripts/local-dev.sh branch --content-reset      # back to upstream main
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
@@ -41,6 +45,8 @@ LOG_DIR="/tmp/blms-dev"
 LOG_FILE="$LOG_DIR/combined.log"
 PID_FILE="$LOG_DIR/dev.pid"
 LOCK_FILE="$LOG_DIR/local-dev.lock"
+UPSTREAM_CONTENT_REPO="https://github.com/PlanB-Network/bitcoin-educational-content"
+UPSTREAM_CONTENT_SLUG="PlanB-Network/bitcoin-educational-content"
 
 # Colors
 RED='\033[0;31m'
@@ -139,6 +145,39 @@ wait_for_api() {
     return 1
 }
 
+restart_dev_servers() {
+    if ! is_dev_running; then
+        info "Dev servers not running, skipping restart"
+        return
+    fi
+
+    info "Restarting dev servers (env vars changed) ..."
+
+    # Stop
+    local pid
+    pid=$(cat "$PID_FILE")
+    local pgid
+    pgid=$(ps -o pgid= -p "$pid" 2>/dev/null | tr -d ' ') || true
+    if [[ -n "$pgid" ]]; then
+        kill -- -"$pgid" 2>/dev/null || true
+    fi
+    kill "$pid" 2>/dev/null || true
+    rm -f "$PID_FILE"
+    pgrep -f "turbo.*dev.*${PROJECT_DIR}" 2>/dev/null | xargs -r kill 2>/dev/null || true
+    pgrep -f "tsx.*${PROJECT_DIR}" 2>/dev/null | xargs -r kill 2>/dev/null || true
+    pgrep -f "vite.*${PROJECT_DIR}" 2>/dev/null | xargs -r kill 2>/dev/null || true
+    sleep 1
+
+    # Start
+    cd "$PROJECT_DIR"
+    pnpm dev 2>&1 \
+        | awk '{ print strftime("[%H:%M:%S]"), $0; fflush() }' \
+        >> "$LOG_FILE" &
+    local dev_pid=$!
+    echo "$dev_pid" > "$PID_FILE"
+    ok "Dev servers restarted (PID ${dev_pid})"
+}
+
 trigger_sync() {
     local pub_branch priv_branch
     pub_branch=$(read_env_var DATA_REPOSITORY_BRANCH "main")
@@ -149,6 +188,12 @@ trigger_sync() {
     if ! wait_for_api; then
         error "Cannot sync — API is not running"
         return 1
+    fi
+
+    # Snapshot log position before sync to only check new lines after
+    local log_lines_before=0
+    if [[ -f "$LOG_FILE" ]]; then
+        log_lines_before=$(wc -l < "$LOG_FILE")
     fi
 
     local response http_code
@@ -163,6 +208,24 @@ trigger_sync() {
         ok "Content synced"
     else
         warn "Sync returned HTTP ${http_code}"
+    fi
+
+    # Check new log lines for sync errors
+    if [[ -f "$LOG_FILE" ]]; then
+        local sync_errors
+        sync_errors=$(tail -n +"$((log_lines_before + 1))" "$LOG_FILE" \
+            | grep -i 'error processing file\|failed to sync\|failed to clone' \
+            | tail -20) || true
+        if [[ -n "$sync_errors" ]]; then
+            echo ""
+            warn "${BOLD}Sync errors detected:${NC}"
+            echo "$sync_errors" | while IFS= read -r line; do
+                local clean
+                clean=$(echo "$line" | sed 's/^\[[0-9:]*\] @blms\/api:dev: //')
+                echo -e "  ${RED}x${NC} ${clean}"
+            done
+            echo ""
+        fi
     fi
 }
 
@@ -337,6 +400,44 @@ cmd_down() {
         fi
     done
 
+    # Reset branches to defaults
+    header "Resetting branches"
+
+    local app_branch
+    app_branch=$(cd "$PROJECT_DIR" && git branch --show-current 2>/dev/null || echo "")
+    if [[ -n "$app_branch" && "$app_branch" != "dev" ]]; then
+        (cd "$PROJECT_DIR" && git checkout dev 2>/dev/null) && ok "App branch: dev" || warn "Could not checkout dev"
+    else
+        ok "App branch already on dev"
+    fi
+
+    if [[ -f "$ENV_FILE" ]]; then
+        local content_url content_branch private_branch
+        content_url=$(read_env_var DATA_REPOSITORY_URL "")
+        content_branch=$(read_env_var DATA_REPOSITORY_BRANCH "main")
+        private_branch=$(read_env_var PRIVATE_DATA_REPOSITORY_BRANCH "")
+
+        local changed=false
+        if [[ -n "$content_url" && "$content_url" != "$UPSTREAM_CONTENT_REPO" ]]; then
+            set_env_var DATA_REPOSITORY_URL "$UPSTREAM_CONTENT_REPO"
+            changed=true
+        fi
+        if [[ "$content_branch" != "dev" ]]; then
+            set_env_var DATA_REPOSITORY_BRANCH "dev"
+            changed=true
+        fi
+        if [[ -n "$private_branch" && "$private_branch" != "dev" ]]; then
+            set_env_var PRIVATE_DATA_REPOSITORY_BRANCH "dev"
+            changed=true
+        fi
+
+        if [[ "$changed" == true ]]; then
+            ok "Content branches reset to dev (upstream)"
+        else
+            ok "Content branches already on dev"
+        fi
+    fi
+
     rm -f "$LOCK_FILE"
     ok "Everything stopped (containers preserved, use 'nuke' to delete)"
 }
@@ -362,10 +463,20 @@ cmd_status() {
 
     # Content branches
     if [[ -f "$ENV_FILE" ]]; then
-        local content_branch private_branch
+        local content_branch private_branch content_repo_url
         content_branch=$(read_env_var DATA_REPOSITORY_BRANCH "main")
         private_branch=$(read_env_var PRIVATE_DATA_REPOSITORY_BRANCH "")
-        echo -e "  Content branch:         ${BOLD}${content_branch}${NC}"
+        content_repo_url=$(read_env_var DATA_REPOSITORY_URL "")
+
+        local fork_indicator=""
+        if [[ -n "$content_repo_url" && "$content_repo_url" != "$UPSTREAM_CONTENT_REPO" ]]; then
+            fork_indicator=" ${YELLOW}(fork)${NC}"
+        fi
+
+        echo -e "  Content branch:         ${BOLD}${content_branch}${NC}${fork_indicator}"
+        if [[ -n "$fork_indicator" ]]; then
+            echo -e "  Content repo:           ${DIM}${content_repo_url}${NC}"
+        fi
         echo -e "  Private content branch: ${BOLD}${private_branch:-not set}${NC}"
     else
         echo -e "  Content branch:         ${DIM}no .env${NC}"
@@ -452,42 +563,55 @@ cmd_logs() {
 
 cmd_branch() {
     local app_branch="" content_branch="" private_branch=""
+    local content_pr="" content_reset=false
     local interactive=true
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --app)             app_branch="$2"; interactive=false; shift 2 ;;
             --content)         content_branch="$2"; interactive=false; shift 2 ;;
+            --content-pr)      content_pr="$2"; interactive=false; shift 2 ;;
+            --content-reset)   content_reset=true; interactive=false; shift ;;
             --private-content) private_branch="$2"; interactive=false; shift 2 ;;
             *)                 error "Unknown flag: $1"; exit 1 ;;
         esac
     done
 
     if [[ "$interactive" == true ]]; then
-        local current_app current_content current_private
+        local current_app current_content current_private current_repo_url
         current_app=$(cd "$PROJECT_DIR" && git branch --show-current 2>/dev/null || echo "unknown")
 
         ensure_env
         current_content=$(read_env_var DATA_REPOSITORY_BRANCH "main")
         current_private=$(read_env_var PRIVATE_DATA_REPOSITORY_BRANCH "")
+        current_repo_url=$(read_env_var DATA_REPOSITORY_URL "")
+
+        local fork_indicator=""
+        if [[ -n "$current_repo_url" && "$current_repo_url" != "$UPSTREAM_CONTENT_REPO" ]]; then
+            fork_indicator=" ${YELLOW}(fork)${NC}"
+        fi
 
         echo ""
         echo -e "  Current state:"
         echo -e "    App:             ${BOLD}${current_app}${NC}"
-        echo -e "    Content:         ${BOLD}${current_content}${NC}"
+        echo -e "    Content:         ${BOLD}${current_content}${NC}${fork_indicator}"
         echo -e "    Private content: ${BOLD}${current_private:-not set}${NC}"
         echo ""
         echo -e "  ${BOLD}1)${NC} Switch app branch"
         echo -e "  ${BOLD}2)${NC} Switch content branch"
-        echo -e "  ${BOLD}3)${NC} Switch both"
-        echo -e "  ${BOLD}4)${NC} Cancel"
+        echo -e "  ${BOLD}3)${NC} Review a content PR (handles forks)"
+        echo -e "  ${BOLD}4)${NC} Reset content to upstream main"
+        echo -e "  ${BOLD}5)${NC} Switch both (app + content)"
+        echo -e "  ${BOLD}6)${NC} Cancel"
         echo ""
-        read -rp "$(echo -e "${CYAN}>${NC}") Choice [1/2/3/4]: " choice
+        read -rp "$(echo -e "${CYAN}>${NC}") Choice [1-6]: " choice
 
         case "$choice" in
             1) _pick_app_branch; app_branch="$PICKED_BRANCH" ;;
             2) _pick_content_branch; content_branch="$PICKED_BRANCH" ;;
-            3)
+            3) _pick_content_pr; content_pr="$PICKED_PR" ;;
+            4) content_reset=true ;;
+            5)
                 _pick_app_branch; app_branch="$PICKED_BRANCH"
                 _pick_content_branch; content_branch="$PICKED_BRANCH"
                 ;;
@@ -519,7 +643,36 @@ cmd_branch() {
     local need_sync=false
     ensure_env
 
+    # --content-reset: restore upstream repo + main branch
+    if [[ "$content_reset" == true ]]; then
+        header "Resetting content to upstream"
+        set_env_var DATA_REPOSITORY_URL "$UPSTREAM_CONTENT_REPO"
+        set_env_var DATA_REPOSITORY_BRANCH "main"
+        ok "Content repo: ${BOLD}${UPSTREAM_CONTENT_REPO}${NC}"
+        ok "Content branch: ${BOLD}main${NC}"
+        need_sync=true
+    fi
+
+    # --content-pr: resolve PR, set fork URL + branch
+    if [[ -n "$content_pr" ]]; then
+        header "Switching to content PR"
+        _resolve_content_pr "$content_pr"
+        set_env_var DATA_REPOSITORY_URL "$PR_REPO_URL"
+        set_env_var DATA_REPOSITORY_BRANCH "$PR_BRANCH"
+        ok "Content repo set to: ${BOLD}${PR_REPO_URL}${NC}"
+        ok "Content branch set to: ${BOLD}${PR_BRANCH}${NC}"
+        need_sync=true
+    fi
+
     if [[ -n "$content_branch" ]]; then
+        # When explicitly setting a branch, reset URL to upstream
+        # (user likely wants a branch from the main repo, not the fork)
+        local current_url
+        current_url=$(read_env_var DATA_REPOSITORY_URL "")
+        if [[ -n "$current_url" && "$current_url" != "$UPSTREAM_CONTENT_REPO" ]]; then
+            info "Resetting content repo URL to upstream (was pointing to a fork)"
+            set_env_var DATA_REPOSITORY_URL "$UPSTREAM_CONTENT_REPO"
+        fi
         set_env_var DATA_REPOSITORY_BRANCH "$content_branch"
         ok "Content branch set to: ${BOLD}${content_branch}${NC}"
         need_sync=true
@@ -532,6 +685,7 @@ cmd_branch() {
     fi
 
     if [[ "$need_sync" == true ]]; then
+        restart_dev_servers
         trigger_sync
     fi
 }
@@ -587,6 +741,85 @@ _pick_content_branch() {
         read -rp "$(echo -e "${CYAN}>${NC}") Branch name: " PICKED_BRANCH
         [[ -z "$PICKED_BRANCH" ]] && { error "No selection"; exit 1; }
     fi
+}
+
+_resolve_content_pr() {
+    local pr_number="$1"
+
+    if ! command -v gh &>/dev/null; then
+        error "gh CLI not found — install it: https://cli.github.com"
+        exit 1
+    fi
+
+    info "Fetching PR #${pr_number} from ${BOLD}${UPSTREAM_CONTENT_SLUG}${NC} ..."
+    local pr_json
+    pr_json=$(gh pr view "$pr_number" --repo "$UPSTREAM_CONTENT_SLUG" \
+        --json headRefName,headRepository,headRepositoryOwner,title,number,state 2>/dev/null) || {
+        error "Could not fetch PR #${pr_number} from ${UPSTREAM_CONTENT_SLUG}"
+        error "Check that the PR number is correct and you have gh auth"
+        exit 1
+    }
+
+    PR_BRANCH=$(echo "$pr_json" | jq -r '.headRefName')
+    PR_TITLE=$(echo "$pr_json" | jq -r '.title')
+    PR_NUMBER=$(echo "$pr_json" | jq -r '.number')
+    PR_STATE=$(echo "$pr_json" | jq -r '.state')
+    local owner repo_name
+    owner=$(echo "$pr_json" | jq -r '.headRepositoryOwner.login')
+    repo_name=$(echo "$pr_json" | jq -r '.headRepository.name')
+    PR_REPO_URL="https://github.com/${owner}/${repo_name}"
+
+    local fork_label=""
+    if [[ "$PR_REPO_URL" != "$UPSTREAM_CONTENT_REPO" ]]; then
+        fork_label=" ${YELLOW}(fork)${NC}"
+    fi
+
+    ok "PR #${PR_NUMBER}: ${PR_TITLE}"
+    info "  Branch: ${BOLD}${PR_BRANCH}${NC}"
+    info "  Repo:   ${BOLD}${PR_REPO_URL}${NC}${fork_label}"
+    info "  State:  ${PR_STATE}"
+}
+
+_pick_content_pr() {
+    if ! command -v gh &>/dev/null; then
+        error "gh CLI not found — install it: https://cli.github.com"
+        exit 1
+    fi
+
+    info "Fetching open PRs from ${BOLD}${UPSTREAM_CONTENT_SLUG}${NC} ..."
+    local pr_list
+    pr_list=$(gh pr list --repo "$UPSTREAM_CONTENT_SLUG" --state open --limit 100 \
+        --json number,title,headRefName,author \
+        --jq '.[] | "#\(.number)  \(.headRefName)  \(.title)  @\(.author.login)"' 2>/dev/null)
+
+    if [[ -z "$pr_list" ]]; then
+        warn "No open PRs found"
+        exit 1
+    fi
+
+    local pr_count
+    pr_count=$(echo "$pr_list" | wc -l | tr -d ' ')
+    info "Found ${BOLD}${pr_count}${NC} open PRs"
+
+    local selection
+    if command -v fzf &>/dev/null; then
+        selection=$(echo "$pr_list" | fzf \
+            --height=~40% \
+            --reverse \
+            --prompt="pr> " \
+            --header="Type to fuzzy-search · ESC to cancel" \
+            --delimiter='  ' \
+            --with-nth=1,3,4 \
+        ) || { error "Cancelled"; exit 1; }
+    else
+        warn "fzf not found — install it for fuzzy search"
+        echo "$pr_list"
+        read -rp "$(echo -e "${CYAN}>${NC}") PR number: " selection
+        [[ -z "$selection" ]] && { error "No selection made"; exit 1; }
+    fi
+
+    # Extract PR number (strip the # prefix)
+    PICKED_PR=$(echo "$selection" | awk -F'  ' '{print $1}' | tr -d '#')
 }
 
 cmd_sync() {

--- a/scripts/local-dev.sh
+++ b/scripts/local-dev.sh
@@ -38,7 +38,8 @@ PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 ENV_FILE="$PROJECT_DIR/.env"
 ENV_EXAMPLE="$PROJECT_DIR/.env.example"
 API_URL="${API_URL:-http://localhost:3000}"
-POSTGRES_CONTAINER="blms-local-postgres"
+# Overridable so `context` presets can target the compose stack's postgres too
+POSTGRES_CONTAINER="${POSTGRES_CONTAINER:-blms-local-postgres}"
 CDN_CONTAINER="blms-local-cdn"
 TYPESENSE_CONTAINER="blms-local-typesense"
 MINIO_CONTAINER="blms-local-minio"
@@ -82,6 +83,8 @@ ensure_env() {
             sed -i 's|^S3_SECRET_KEY=.*|S3_SECRET_KEY=minioadmin|' "$ENV_FILE"
             sed -i 's|^S3_BUCKET=.*|S3_BUCKET=blms-local|' "$ENV_FILE"
             sed -i 's|^S3_REGION=.*|S3_REGION=us-east-1|' "$ENV_FILE"
+            sed -i 's|^S3_FORCE_PATH_STYLE=.*|S3_FORCE_PATH_STYLE=true|' "$ENV_FILE"
+            grep -q '^S3_FORCE_PATH_STYLE=' "$ENV_FILE" || echo 'S3_FORCE_PATH_STYLE=true' >> "$ENV_FILE"
             ok ".env created with local defaults"
             warn "Edit .env to add GITHUB_ACCESS_TOKEN if you need private content repo"
         else
@@ -245,6 +248,13 @@ cmd_up() {
 
     # .env
     ensure_env
+    # Guard: the docker-compose stack (README option 1) binds the same ports
+    if docker ps --format '{{.Names}}' 2>/dev/null | grep -q '^bitcoin-learning-management-system-'; then
+        error "The docker compose stack is running (bitcoin-learning-management-system-*)."
+        error "It binds the same ports (5432, 8108, 9000). Stop it first:"
+        error "    docker compose down"
+        exit 1
+    fi
 
     # node_modules
     if [[ ! -d "$PROJECT_DIR/node_modules" ]]; then
@@ -341,6 +351,9 @@ cmd_up() {
         set_env_var S3_SECRET_KEY "minioadmin"
         set_env_var S3_BUCKET "blms-local"
         set_env_var S3_REGION "us-east-1"
+    fi
+    if [[ "$(read_env_var S3_FORCE_PATH_STYLE "")" != "true" ]]; then
+        set_env_var S3_FORCE_PATH_STYLE "true"
     fi
 
     # MinIO (S3-compatible storage — required by sync for assignment PDFs)
@@ -970,6 +983,93 @@ _resolve_course() {
     fi
     echo "$course_id"
 }
+# Course granting access to the career portal (BTC402, see COURSES_CAREER_ACCESS)
+CAREER_COURSE_ID="0b71eea1-4811-4601-a6ad-38d043b52dca"
+
+_ensure_career_access() {
+    local uid="$1"
+    # Course row must exist (FK). Create a minimal stub if content is not synced.
+    local course
+    course=$(_db "SELECT id FROM content.courses WHERE id = '${CAREER_COURSE_ID}';")
+    if [[ -z "$course" ]]; then
+        info "Course BTC402 not in DB (content not synced) — creating stub"
+        _db "INSERT INTO content.courses (id, level, hours, topic, subtopic, last_commit, index)
+             VALUES ('${CAREER_COURSE_ID}', 'beginner', 1, 'bitcoin', 'career', 'local-dev-stub', 'btc402');" > /dev/null
+    fi
+    local paid
+    paid=$(_db "SELECT 1 FROM users.course_payment WHERE uid = '${uid}' AND course_id = '${CAREER_COURSE_ID}' AND payment_status = 'paid';")
+    if [[ -z "$paid" ]]; then
+        _db "INSERT INTO users.course_payment (uid, course_id, payment_status, amount, payment_id, method)
+             VALUES ('${uid}', '${CAREER_COURSE_ID}', 'paid', 0, 'local-dev-grant', 'free');" > /dev/null
+    fi
+    ok "Career portal access granted (paid BTC402)"
+}
+
+_ensure_career_profile() {
+    # Creates/returns a career profile id for the user.
+    # IMPORTANT: always use gen_random_uuid() — zod validates UUIDs strictly
+    # (hand-crafted ids like 1111... fail output validation with an opaque 500).
+    local uid="$1"
+    local pid
+    pid=$(_db "SELECT id FROM users.career_profiles WHERE uid = '${uid}';")
+    if [[ -z "$pid" ]]; then
+        pid=$(_db "INSERT INTO users.career_profiles (uid, id) VALUES ('${uid}', gen_random_uuid()) RETURNING id;" | head -n1)
+    fi
+    echo "$pid"
+}
+
+_career_fill_step1() {
+    local uid="$1" pid="$2"
+    _db "UPDATE users.career_profiles SET
+            first_name = 'Test', last_name = 'User', country = 'France', email = '${TEST_EMAIL}'
+         WHERE id = '${pid}';" > /dev/null
+    _db "INSERT INTO users.career_languages (career_profile_id, language_code, level)
+         VALUES ('${pid}', 'en', 'fluent') ON CONFLICT DO NOTHING;" > /dev/null
+}
+
+_career_fill_step2() {
+    local pid="$1"
+    # job_titles is seeded by migrations; pick a real row (never invent ids)
+    _db "INSERT INTO users.career_roles (career_profile_id, role_id, level)
+         SELECT '${pid}', id, 'junior' FROM users.job_titles LIMIT 1
+         ON CONFLICT DO NOTHING;" > /dev/null
+    _db "INSERT INTO users.career_company_sizes (career_profile_id, size)
+         VALUES ('${pid}', '1To10') ON CONFLICT DO NOTHING;" > /dev/null
+}
+
+_career_fill_step3() {
+    local pid="$1"
+    _db "UPDATE users.career_profiles SET
+            cv_url = '/api/files/cvs/${pid}',
+            motivation_letter = 'Local-dev seeded motivation letter.'
+         WHERE id = '${pid}';" > /dev/null
+}
+
+_apply_career_preset() {
+    local preset="$1" uid="$2"
+    _ensure_career_access "$uid"
+    local pid
+    pid=$(_ensure_career_profile "$uid")
+    case "$preset" in
+        career-access) ;; # access only, no profile data
+        career-step1) _career_fill_step1 "$uid" "$pid" ;;
+        career-step2) _career_fill_step1 "$uid" "$pid"; _career_fill_step2 "$pid" ;;
+        career-step3) _career_fill_step1 "$uid" "$pid"; _career_fill_step2 "$pid"; _career_fill_step3 "$pid" ;;
+        career-complete)
+            _career_fill_step1 "$uid" "$pid"; _career_fill_step2 "$pid"; _career_fill_step3 "$pid"
+            _db "UPDATE users.career_profiles SET are_terms_accepted = true, allow_receiving_emails = true WHERE id = '${pid}';" > /dev/null
+            ;;
+        career-reset)
+            _db "DELETE FROM users.career_profiles WHERE uid = '${uid}';" > /dev/null
+            ok "Career profile deleted"
+            return
+            ;;
+    esac
+    ok "Preset '${preset}' applied (profile ${pid})"
+    _db_pretty "SELECT first_name, country, cv_url IS NOT NULL AS has_cv, motivation_letter IS NOT NULL AS has_letter, are_terms_accepted, allow_receiving_emails
+                FROM users.career_profiles WHERE id = '${pid}';"
+}
+
 
 _apply_preset() {
     local preset="$1" uid="$2" course_id="$3"
@@ -1057,6 +1157,10 @@ _apply_preset() {
             echo "  assignment-submitted  — has submitted work"
             echo "  not-selected          — not selected for assignment"
             echo "  clean                 — reset all assignment fields to null"
+            echo "  career-access         — grant career portal access (paid BTC402)"
+            echo "  career-step1|2|3      — career profile filled up to step N"
+            echo "  career-complete       — career profile fully validated"
+            echo "  career-reset          — delete career profile"
             exit 1
             ;;
     esac
@@ -1109,6 +1213,14 @@ cmd_context() {
         echo -e "  ${BOLD}not-selected${NC}           not selected for assignment"
         echo -e "  ${BOLD}clean${NC}                  reset all assignment fields"
         echo ""
+        echo -e "  ${BOLD}career-access${NC}          grant career portal access (paid BTC402)"
+        echo -e "  ${BOLD}career-step1|2|3${NC}       career profile filled up to step N"
+        echo -e "  ${BOLD}career-complete${NC}        career profile fully validated"
+        echo -e "  ${BOLD}career-reset${NC}           delete career profile"
+        echo ""
+        echo "Career presets don't need --course:"
+        echo "  ./scripts/local-dev.sh context --preset career-step3"
+        echo ""
         echo "Usage: ./scripts/local-dev.sh context --preset <name> --course <id-or-name>"
         return
     fi
@@ -1116,6 +1228,11 @@ cmd_context() {
     # Ensure test user exists
     local uid
     uid=$(_ensure_test_user)
+    # Career presets are course-independent
+    if [[ "$preset" == career-* ]]; then
+        _apply_career_preset "$preset" "$uid"
+        return
+    fi
 
     if [[ "$setup" == true && -z "$course" ]]; then
         echo ""

--- a/scripts/local-dev.sh
+++ b/scripts/local-dev.sh
@@ -41,6 +41,7 @@ API_URL="${API_URL:-http://localhost:3000}"
 POSTGRES_CONTAINER="blms-local-postgres"
 CDN_CONTAINER="blms-local-cdn"
 TYPESENSE_CONTAINER="blms-local-typesense"
+MINIO_CONTAINER="blms-local-minio"
 LOG_DIR="/tmp/blms-dev"
 LOG_FILE="$LOG_DIR/combined.log"
 PID_FILE="$LOG_DIR/dev.pid"
@@ -76,6 +77,11 @@ ensure_env() {
             sed -i 's|^POSTGRES_DB=.*|POSTGRES_DB=postgres|' "$ENV_FILE"
             sed -i 's|^POSTGRES_USER=.*|POSTGRES_USER=postgres|' "$ENV_FILE"
             sed -i 's|^POSTGRES_PASSWORD=.*|POSTGRES_PASSWORD=postgres|' "$ENV_FILE"
+            sed -i 's|^S3_ENDPOINT=.*|S3_ENDPOINT=http://localhost:9000|' "$ENV_FILE"
+            sed -i 's|^S3_ACCESS_KEY=.*|S3_ACCESS_KEY=minioadmin|' "$ENV_FILE"
+            sed -i 's|^S3_SECRET_KEY=.*|S3_SECRET_KEY=minioadmin|' "$ENV_FILE"
+            sed -i 's|^S3_BUCKET=.*|S3_BUCKET=blms-local|' "$ENV_FILE"
+            sed -i 's|^S3_REGION=.*|S3_REGION=us-east-1|' "$ENV_FILE"
             ok ".env created with local defaults"
             warn "Edit .env to add GITHUB_ACCESS_TOKEN if you need private content repo"
         else
@@ -325,6 +331,59 @@ cmd_up() {
         ok "CDN running on localhost:8080"
     fi
 
+    # Ensure .env S3 vars point to local MinIO (before starting container so bucket name is correct)
+    local current_s3_endpoint
+    current_s3_endpoint=$(read_env_var S3_ENDPOINT "")
+    if [[ "$current_s3_endpoint" != "http://localhost:9000" ]]; then
+        info "Patching S3 env vars for local MinIO"
+        set_env_var S3_ENDPOINT "http://localhost:9000"
+        set_env_var S3_ACCESS_KEY "minioadmin"
+        set_env_var S3_SECRET_KEY "minioadmin"
+        set_env_var S3_BUCKET "blms-local"
+        set_env_var S3_REGION "us-east-1"
+    fi
+
+    # MinIO (S3-compatible storage — required by sync for assignment PDFs)
+    if is_container_running "$MINIO_CONTAINER"; then
+        ok "MinIO already running"
+    else
+        if docker ps -a --filter "name=^${MINIO_CONTAINER}$" --format '{{.Names}}' 2>/dev/null | grep -q "^${MINIO_CONTAINER}$"; then
+            info "Restarting MinIO container (data preserved) ..."
+            docker start "$MINIO_CONTAINER" > /dev/null
+        else
+            info "Creating MinIO container ..."
+            docker run -d \
+                --name "$MINIO_CONTAINER" \
+                -p 127.0.0.1:9000:9000 \
+                -p 127.0.0.1:9001:9001 \
+                -e MINIO_ROOT_USER=minioadmin \
+                -e MINIO_ROOT_PASSWORD=minioadmin \
+                -v blms-local-minio-data:/data \
+                --restart unless-stopped \
+                minio/minio server /data --console-address ":9001" > /dev/null
+        fi
+        info "Waiting for MinIO ..."
+        for i in $(seq 1 20); do
+            if curl -sf http://localhost:9000/minio/health/live > /dev/null 2>&1; then
+                break
+            fi
+            sleep 1
+        done
+        ok "MinIO running on localhost:9000 (console: localhost:9001)"
+
+        # Create bucket if it doesn't exist (uses minio/mc image as a one-shot tool)
+        local bucket
+        bucket=$(read_env_var S3_BUCKET "blms-local")
+        if docker run --rm --net=host --entrypoint sh minio/mc -c \
+            "mc alias set local http://localhost:9000 minioadmin minioadmin > /dev/null 2>&1 \
+             && mc mb local/${bucket} --ignore-existing > /dev/null 2>&1"; then
+            ok "S3 bucket '${bucket}' ready"
+        else
+            warn "Could not auto-create S3 bucket '${bucket}'"
+            info "Create it manually via the MinIO console at http://localhost:9001"
+        fi
+    fi
+
     # Dev servers
     header "Dev servers"
 
@@ -354,8 +413,9 @@ cmd_up() {
 
     header "Ready"
     echo ""
-    echo -e "  ${GREEN}App running at:${NC}  ${BOLD}http://localhost:8181${NC}"
-    echo -e "  ${GREEN}API running at:${NC}  ${BOLD}http://localhost:3000${NC}"
+    echo -e "  ${GREEN}App running at:${NC}    ${BOLD}http://localhost:8181${NC}"
+    echo -e "  ${GREEN}API running at:${NC}    ${BOLD}http://localhost:3000${NC}"
+    echo -e "  ${GREEN}MinIO console:${NC}     ${BOLD}http://localhost:9001${NC}  ${DIM}(minioadmin/minioadmin)${NC}"
     echo ""
     echo -e "  Logs:    ${BOLD}cat ${LOG_FILE}${NC}"
     echo -e "  Errors:  ${BOLD}./scripts/local-dev.sh logs --errors${NC}"
@@ -391,7 +451,7 @@ cmd_down() {
     fi
 
     # Stop containers (keep them — restart is faster than recreate)
-    for container in "$CDN_CONTAINER" "$TYPESENSE_CONTAINER" "$POSTGRES_CONTAINER"; do
+    for container in "$CDN_CONTAINER" "$TYPESENSE_CONTAINER" "$MINIO_CONTAINER" "$POSTGRES_CONTAINER"; do
         if is_container_running "$container"; then
             docker stop "$container" > /dev/null
             ok "Stopped $container"
@@ -445,10 +505,11 @@ cmd_down() {
 cmd_nuke() {
     header "Nuking everything"
     cmd_down
-    for container in "$CDN_CONTAINER" "$TYPESENSE_CONTAINER" "$POSTGRES_CONTAINER"; do
+    for container in "$CDN_CONTAINER" "$TYPESENSE_CONTAINER" "$MINIO_CONTAINER" "$POSTGRES_CONTAINER"; do
         docker rm "$container" 2>/dev/null && ok "Removed $container" || true
     done
     docker volume rm blms-local-pgdata 2>/dev/null && ok "Removed PostgreSQL data volume" || true
+    docker volume rm blms-local-minio-data 2>/dev/null && ok "Removed MinIO data volume" || true
     rm -rf "$LOG_DIR"
     ok "All data destroyed. Next 'up' will be a fresh start."
 }
@@ -485,9 +546,10 @@ cmd_status() {
     echo ""
 
     # Services
-    local pg_status cdn_status api_status academy_status dev_status
+    local pg_status cdn_status minio_status api_status academy_status dev_status
     if is_container_running "$POSTGRES_CONTAINER"; then pg_status="${GREEN}running${NC}"; else pg_status="${RED}stopped${NC}"; fi
     if is_container_running "$CDN_CONTAINER"; then cdn_status="${GREEN}running${NC}"; else cdn_status="${RED}stopped${NC}"; fi
+    if is_container_running "$MINIO_CONTAINER"; then minio_status="${GREEN}running${NC}"; else minio_status="${RED}stopped${NC}"; fi
     if is_dev_running; then
         dev_status="${GREEN}running${NC} (PID $(cat "$PID_FILE"))"
     else
@@ -505,6 +567,7 @@ cmd_status() {
     fi
 
     echo -e "  PostgreSQL (docker):  ${pg_status}  :5432"
+    echo -e "  MinIO S3 (docker):    ${minio_status}  :9000 (console :9001)"
     echo -e "  CDN nginx (docker):   ${cdn_status}  :8080"
     echo -e "  Dev servers:          ${dev_status}"
     echo -e "    API:                ${api_status}  :3000"


### PR DESCRIPTION
## Summary

Extends local-dev.sh with two capabilities that make local development self-sufficient:

### PR review support (57ea0e6)
- `local-dev.sh branch --content <branch>` switches the content branch and re-syncs
- `local-dev.sh sync` now reports error counts, enabling agent-driven review workflows
- Structured exit codes for scripted usage

### MinIO S3 storage (81b228a)
- **Problem**: Local sync produced 54 ECONNREFUSED errors because no S3 service existed locally. This also blocked garbage collection (entity cleanup) since it only runs when syncErrors.length === 0.
- **Solution**: Added MinIO as a local S3-compatible object store, fully managed by local-dev.sh
- Container lifecycle integrated into up/down/nuke/status
- Auto-creates bucket on first start (via one-shot minio/mc container)
- Patches S3 environment variables automatically (both on fresh setup and existing installs)
- S3 client auto-detects non-AWS endpoints and uses path-style addressing (1-line heuristic, no config flag needed)
- MinIO console exposed at localhost:9001 for inspecting stored objects

### Result
- **Before**: 55 sync errors (54 S3 + 1 content bug), GC never runs
- **After**: 0 sync errors on dev, 54 assignment PDFs stored locally

## Test plan
- [x] local-dev.sh up — MinIO starts, bucket created, env patched
- [x] local-dev.sh up (again) — idempotent, skips existing MinIO
- [x] local-dev.sh sync on dev — 0 errors, PDFs uploaded to MinIO
- [x] local-dev.sh status — shows MinIO status
- [x] local-dev.sh nuke — removes MinIO container + volume

## Deployment note

Do **not** set `S3_FORCE_PATH_STYLE` on testnet/mainnet env. It defaults to `false` (vhost-style), which is identical to the currently deployed behavior on OVH S3. The flag is only needed for local MinIO (`local-dev.sh` and compose set it automatically).
