### PR TITLE
feat: add prerender service for SEO and AI crawler visibility

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -328,6 +328,49 @@ jobs:
           cache-from: type=gha,scope=global
           cache-to: type=gha,mode=max,scope=global
 
+  build_prerender:
+    name: Build Prerender
+    if: (github.event_name == 'push') && (github.ref == 'refs/heads/mainnet' || github.ref == 'refs/heads/testnet')
+    runs-on: ubuntu-latest
+    env:
+      image: ghcr.io/planb-network/blms-prerender
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set Docker image metadata for prerender
+        uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.image }}
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha,prefix=sha-
+
+      - name: Build and push Docker image for prerender
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          file: ./docker/prerender/Dockerfile
+          context: ./docker/prerender
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha,scope=global
+          cache-to: type=gha,mode=max,scope=global
+
   deploy:
     name: Deploy hook
     if: (github.event_name == 'push') && (github.ref == 'refs/heads/mainnet' || github.ref == 'refs/heads/testnet')
@@ -339,6 +382,7 @@ jobs:
       - build_contribute
       - build_design_system
       - build_pear_sync
+      - build_prerender
     steps:
       - name: Invoke deployment hook
         uses: distributhor/workflow-webhook@v3

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -9,6 +9,10 @@ on:
       - dev
   pull_request:
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build_base:
     name: Build & Test

--- a/apps/academy/docker/nginx.conf
+++ b/apps/academy/docker/nginx.conf
@@ -28,6 +28,17 @@ http {
         "" $http_x_real_ip;
     }
 
+    # Block indexing on non-production domains (testnet)
+    map $host $robots_tag {
+        "~*testnet"  '<meta name="robots" content="noindex, nofollow">';
+        default      '';
+    }
+
+    map $host $robots_disallow {
+        "~*testnet"  "/";
+        default      "";
+    }
+
     log_format  main  '$time_iso8601_ms $request_id $real_ip $request_method "$request_uri" '
                       '$status $request_time $body_bytes_sent "$http_referer" "$http_user_agent"';
 
@@ -116,6 +127,12 @@ http {
             return 204;
         }
 
+        # Dynamic robots.txt — blocks crawling on testnet
+        location = /robots.txt {
+            default_type text/plain;
+            return 200 "User-agent: *\nDisallow: $robots_disallow\n";
+        }
+
         location = /service-worker.js {
             expires 10s;
             add_header Cache-Control "public, max-age=10, must-revalidate";
@@ -186,6 +203,9 @@ http {
                 <meta name=\"twitter:image\" content=\"$image\">
                 <meta name=\"twitter:card\" content=\"summary_large_image\">
             ";
+
+            # Inject noindex on testnet (empty string on mainnet — no effect)
+            sub_filter '</head>' '${robots_tag}</head>';
         }
     }
 }

--- a/apps/academy/docker/nginx.conf
+++ b/apps/academy/docker/nginx.conf
@@ -30,12 +30,12 @@ http {
 
     # Block indexing on non-production domains (testnet)
     map $host $robots_tag {
-        "~*testnet"  '<meta name="robots" content="noindex, nofollow">';
+        "~*planbtest"  '<meta name="robots" content="noindex, nofollow">';
         default      '';
     }
 
     map $host $robots_disallow {
-        "~*testnet"  "/";
+        "~*planbtest"  "/";
         default      "";
     }
 

--- a/apps/academy/src/main.tsx
+++ b/apps/academy/src/main.tsx
@@ -24,8 +24,12 @@ declare global {
 
   interface Window {
     Pear?: Pear;
+    prerenderReady?: boolean;
   }
 }
+
+// Signal prerender to wait for the app to finish rendering
+window.prerenderReady = false;
 
 // Pear update handling
 if (isPearApp && typeof Pear !== 'undefined') {

--- a/apps/academy/src/providers/app.tsx
+++ b/apps/academy/src/providers/app.tsx
@@ -150,10 +150,27 @@ export const AppProvider = ({ children }: PropsWithChildren) => {
     };
   }, [currentLanguage]);
 
-  // Signal prerender that the page is ready for snapshotting
+  // Signal prerender that the page is ready for snapshotting.
+  // Wait for queries to start AND finish before signaling — prerenderReady
+  // firing too early causes prerender to snapshot a loading skeleton.
   useEffect(() => {
-    (window as any).prerenderReady = true;
-  }, []);
+    let hasStartedFetching = false;
+    const unsub = queryClient.getQueryCache().subscribe(() => {
+      const fetching = queryClient.isFetching();
+      if (fetching > 0) hasStartedFetching = true;
+      if (hasStartedFetching && fetching === 0) {
+        window.prerenderReady = true;
+      }
+    });
+    // Fallback: pages with no queries (e.g. static) still signal ready
+    const fallback = setTimeout(() => {
+      window.prerenderReady = true;
+    }, 3000);
+    return () => {
+      unsub();
+      clearTimeout(fallback);
+    };
+  }, [queryClient]);
 
   return (
     <HelmetProvider>

--- a/apps/academy/src/providers/app.tsx
+++ b/apps/academy/src/providers/app.tsx
@@ -150,6 +150,11 @@ export const AppProvider = ({ children }: PropsWithChildren) => {
     };
   }, [currentLanguage]);
 
+  // Signal prerender that the page is ready for snapshotting
+  useEffect(() => {
+    (window as any).prerenderReady = true;
+  }, []);
+
   return (
     <HelmetProvider>
       <QueryClientProvider client={queryClient}>

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -84,6 +84,31 @@ services:
     volumes:
       - ./well-known:/usr/share/nginx/html/.well-known:ro
 
+  # Prerender — serves pre-rendered HTML to search engine and AI crawlers
+  # Bot UA detection via Traefik HeadersRegexp, priority 100 (above academy default)
+  # Source list: https://github.com/monperrus/crawler-user-agents
+  prerender:
+    <<: *defaults
+    image: ghcr.io/planb-network/blms-prerender:${IMAGE_TAG}
+    environment:
+      PORT: "3000"
+    expose:
+      - 3000
+    shm_size: 1gb
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.university-prerender-${ENV}.rule=Host(`${DOMAIN_ACADEMY}`) && HeadersRegexp(`User-Agent`, `(?i)(googlebot|bingbot|yandex|baiduspider|duckduckbot|facebookexternalhit|twitterbot|linkedinbot|slackbot|telegrambot|whatsapp|discordbot|applebot|gptbot|oai-searchbot|chatgpt-user|claudebot|claude-web|perplexitybot|google-extended|applebot-extended|amazonbot|bytespider|deepseekbot|meta-externalagent|ccbot|diffbot|petalbot)`)
+      - traefik.http.routers.university-prerender-${ENV}.entrypoints=https
+      - traefik.http.routers.university-prerender-${ENV}.tls=true
+      - traefik.http.routers.university-prerender-${ENV}.priority=100
+      - traefik.http.services.university-prerender-${ENV}.loadbalancer.server.port=3000
+      - traefik.http.routers.university-prerender-${ENV}.middlewares=prerender-prefix-${ENV}
+      - traefik.http.middlewares.prerender-prefix-${ENV}.addprefix.prefix=/https://${DOMAIN_ACADEMY}
+
   network:
     <<: *defaults
     image: ghcr.io/planb-network/blms-network:${IMAGE_TAG}

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -92,13 +92,21 @@ services:
     image: ghcr.io/planb-network/blms-prerender:${IMAGE_TAG}
     environment:
       PORT: "3000"
+      CACHE_MAXSIZE: "20000"
+      CACHE_TTL: "86400"
     expose:
       - 3000
     shm_size: 1gb
     deploy:
       resources:
         limits:
-          memory: 2G
+          memory: 8G
+    healthcheck:
+      test: ['CMD', 'curl', '-sf', 'http://localhost:3000/render?url=http://localhost']
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
     labels:
       - traefik.enable=true
       - traefik.http.routers.university-prerender-${ENV}.rule=Host(`${DOMAIN_ACADEMY}`) && HeadersRegexp(`User-Agent`, `(?i)(googlebot|bingbot|yandex|baiduspider|duckduckbot|facebookexternalhit|twitterbot|linkedinbot|slackbot|telegrambot|whatsapp|discordbot|applebot|gptbot|oai-searchbot|chatgpt-user|claudebot|claude-web|perplexitybot|google-extended|applebot-extended|amazonbot|bytespider|deepseekbot|meta-externalagent|ccbot|diffbot|petalbot)`)

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -102,11 +102,11 @@ services:
         limits:
           memory: 8G
     healthcheck:
-      test: ['CMD', 'curl', '-sf', 'http://localhost:3000/render?url=http://localhost']
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 15s
+      <<: *healthcheck
+      test: ['CMD', 'curl', '-sf', 'http://localhost:3000/healthz']
+      interval: 60s
+      timeout: 15s
+      start_period: 30s
     labels:
       - traefik.enable=true
       - traefik.http.routers.university-prerender-${ENV}.rule=Host(`${DOMAIN_ACADEMY}`) && HeadersRegexp(`User-Agent`, `(?i)(googlebot|bingbot|yandex|baiduspider|duckduckbot|facebookexternalhit|twitterbot|linkedinbot|slackbot|telegrambot|whatsapp|discordbot|applebot|gptbot|oai-searchbot|chatgpt-user|claudebot|claude-web|perplexitybot|google-extended|applebot-extended|amazonbot|bytespider|deepseekbot|meta-externalagent|ccbot|diffbot|petalbot)`)
@@ -114,8 +114,12 @@ services:
       - traefik.http.routers.university-prerender-${ENV}.tls=true
       - traefik.http.routers.university-prerender-${ENV}.priority=100
       - traefik.http.services.university-prerender-${ENV}.loadbalancer.server.port=3000
-      - traefik.http.routers.university-prerender-${ENV}.middlewares=prerender-prefix-${ENV}
+      - traefik.http.routers.university-prerender-${ENV}.middlewares=prerender-ratelimit-${ENV},prerender-prefix-${ENV}
       - traefik.http.middlewares.prerender-prefix-${ENV}.addprefix.prefix=/https://${DOMAIN_ACADEMY}
+      - traefik.http.middlewares.prerender-ratelimit-${ENV}.ratelimit.average=2
+      - traefik.http.middlewares.prerender-ratelimit-${ENV}.ratelimit.period=1s
+      - traefik.http.middlewares.prerender-ratelimit-${ENV}.ratelimit.burst=20
+      - traefik.http.middlewares.prerender-ratelimit-${ENV}.ratelimit.sourcecriterion.ipstrategy.depth=1
 
   network:
     <<: *defaults

--- a/docker/prerender/Dockerfile
+++ b/docker/prerender/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:24-alpine
+
+RUN apk add --no-cache chromium tini curl
+
+ENV CHROME_BIN=/usr/bin/chromium-browser
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+ENV PORT=3000
+
+WORKDIR /app
+COPY package.json server.js ./
+RUN npm install --production && npm cache clean --force
+
+EXPOSE 3000
+ENTRYPOINT ["tini", "--"]
+CMD ["node", "server.js"]

--- a/docker/prerender/Dockerfile
+++ b/docker/prerender/Dockerfile
@@ -1,15 +1,18 @@
 FROM node:24-alpine
 
-RUN apk add --no-cache chromium tini curl
+RUN apk add --no-cache chromium tini curl \
+ && addgroup -S prerender && adduser -S -G prerender prerender
 
 ENV CHROME_BIN=/usr/bin/chromium-browser
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 ENV PORT=3000
 
 WORKDIR /app
-COPY package.json server.js ./
-RUN npm install --production && npm cache clean --force
+COPY package.json server.js cache-plugin.js ./
+RUN npm install --production && npm cache clean --force \
+ && chown -R prerender:prerender /app
 
+USER prerender
 EXPOSE 3000
 ENTRYPOINT ["tini", "--"]
 CMD ["node", "server.js"]

--- a/docker/prerender/cache-plugin.js
+++ b/docker/prerender/cache-plugin.js
@@ -1,0 +1,95 @@
+/**
+ * Stale-while-revalidate cache plugin for prerender.
+ *
+ * - Cache hit (fresh): serve immediately.
+ * - Cache hit (stale, past TTL): serve stale content immediately,
+ *   trigger a background re-render so next request gets fresh content.
+ * - Cache miss: render normally, cache the result.
+ *
+ * Env vars:
+ *   CACHE_MAXSIZE  — max entries (default 20000)
+ *   CACHE_TTL      — fresh duration in seconds (default 86400 = 24h)
+ */
+
+const CACHE_MAXSIZE = Number.parseInt(process.env.CACHE_MAXSIZE, 10) || 20000;
+const CACHE_TTL_MS =
+  (Number.parseInt(process.env.CACHE_TTL, 10) || 86400) * 1000;
+
+// Simple LRU via Map (insertion-order iteration, delete+re-set to refresh)
+const cache = new Map(); // url → { content, createdAt }
+const revalidating = new Set(); // urls currently being re-rendered
+
+function evictIfNeeded() {
+  while (cache.size > CACHE_MAXSIZE) {
+    const oldest = cache.keys().next().value;
+    cache.delete(oldest);
+  }
+}
+
+module.exports = {
+  requestReceived: (req, res, next) => {
+    const url = req.prerender.url;
+
+    // Bypass cache for background revalidation requests
+    if (req.headers?.['x-cache-bypass']) {
+      return next();
+    }
+
+    const entry = cache.get(url);
+
+    if (!entry) return next();
+
+    const age = Date.now() - entry.createdAt;
+    const isFresh = age < CACHE_TTL_MS;
+
+    // Serve cached content (fresh or stale)
+    req.prerender.cacheHit = true;
+    res.send(200, entry.content);
+
+    // If stale, trigger background re-render
+    if (!isFresh && !revalidating.has(url)) {
+      revalidating.add(url);
+      console.log(`[cache] stale-while-revalidate: ${url}`);
+
+      const http = require('http');
+      const port = process.env.PORT || 3000;
+      const request = http.get(
+        `http://localhost:${port}/${url}`,
+        { headers: { 'x-cache-bypass': '1' } },
+        (response) => {
+          let body = '';
+          response.on('data', (chunk) => {
+            body += chunk;
+          });
+          response.on('end', () => {
+            if (response.statusCode === 200 && body.length > 0) {
+              cache.delete(url);
+              cache.set(url, { content: body, createdAt: Date.now() });
+              evictIfNeeded();
+              console.log(`[cache] revalidated: ${url} (${body.length} bytes)`);
+            }
+            revalidating.delete(url);
+          });
+        },
+      );
+      request.on('error', () => revalidating.delete(url));
+      request.setTimeout(30000, () => {
+        request.destroy();
+        revalidating.delete(url);
+      });
+    }
+  },
+
+  beforeSend: (req, _res, next) => {
+    if (!req.prerender.cacheHit && req.prerender.statusCode === 200) {
+      const url = req.prerender.url;
+      cache.delete(url);
+      cache.set(url, {
+        content: req.prerender.content,
+        createdAt: Date.now(),
+      });
+      evictIfNeeded();
+    }
+    next();
+  },
+};

--- a/docker/prerender/package.json
+++ b/docker/prerender/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "blms-prerender",
+  "private": true,
+  "dependencies": {
+    "prerender": "^5.21.6"
+  }
+}

--- a/docker/prerender/server.js
+++ b/docker/prerender/server.js
@@ -11,6 +11,7 @@ const server = prerender({
     '--no-zygote',
     '--disable-extensions',
     '--disable-background-networking',
+    '--remote-debugging-address=127.0.0.1',
     '--remote-debugging-port=9222',
     '--js-flags=--max-old-space-size=512',
   ],
@@ -19,8 +20,32 @@ const server = prerender({
   waitAfterLastRequest: 500,
 });
 
-server.use(require('./cache-plugin'));
-server.use(prerender.removeScriptTags());
+// Strip <script> tags but preserve JSON-LD (application/ld+json) so structured
+// data markup survives prerender output. Replaces prerender.removeScriptTags().
+server.use({
+  pageLoaded: (req, res, next) => {
+    if (req.prerender.content) {
+      req.prerender.content = req.prerender.content.replace(
+        /<script\b([^>]*)>([\s\S]*?)<\/script>/gi,
+        (match, attrs) =>
+          /type\s*=\s*["']application\/ld\+json["']/i.test(attrs) ? match : '',
+      );
+    }
+    next();
+  },
+});
 server.use(prerender.httpHeaders());
+server.use(require('./cache-plugin'));
+
+// Healthcheck endpoint — returns 200 without rendering
+server.use({
+  requestReceived: (req, res, next) => {
+    if (req.prerender.url === 'healthz') {
+      res.send(200, 'ok');
+    } else {
+      next();
+    }
+  },
+});
 
 server.start();

--- a/docker/prerender/server.js
+++ b/docker/prerender/server.js
@@ -1,0 +1,25 @@
+const prerender = require('prerender');
+
+const server = prerender({
+  chromeLocation: '/usr/bin/chromium-browser',
+  chromeFlags: [
+    '--no-sandbox',
+    '--headless=new',
+    '--disable-gpu',
+    '--disable-dev-shm-usage',
+    '--disable-setuid-sandbox',
+    '--no-zygote',
+    '--disable-extensions',
+    '--disable-background-networking',
+    '--remote-debugging-port=9222',
+    '--js-flags=--max-old-space-size=512',
+  ],
+  logRequests: true,
+  pageLoadTimeout: 30000,
+  waitAfterLastRequest: 3000,
+});
+
+server.use(prerender.removeScriptTags());
+server.use(prerender.httpHeaders());
+
+server.start();

--- a/docker/prerender/server.js
+++ b/docker/prerender/server.js
@@ -20,20 +20,9 @@ const server = prerender({
   waitAfterLastRequest: 500,
 });
 
-// Strip <script> tags but preserve JSON-LD (application/ld+json) so structured
-// data markup survives prerender output. Replaces prerender.removeScriptTags().
-server.use({
-  pageLoaded: (req, res, next) => {
-    if (req.prerender.content) {
-      req.prerender.content = req.prerender.content.replace(
-        /<script\b([^>]*)>([\s\S]*?)<\/script>/gi,
-        (match, attrs) =>
-          /type\s*=\s*["']application\/ld\+json["']/i.test(attrs) ? match : '',
-      );
-    }
-    next();
-  },
-});
+// removeScriptTags already preserves <script type="application/ld+json"> upstream,
+// so no custom stripping is needed to keep structured data safe.
+server.use(prerender.removeScriptTags());
 server.use(prerender.httpHeaders());
 server.use(require('./cache-plugin'));
 

--- a/docker/prerender/server.js
+++ b/docker/prerender/server.js
@@ -15,10 +15,11 @@ const server = prerender({
     '--js-flags=--max-old-space-size=512',
   ],
   logRequests: true,
-  pageLoadTimeout: 30000,
-  waitAfterLastRequest: 3000,
+  pageLoadTimeout: 10000,
+  waitAfterLastRequest: 500,
 });
 
+server.use(require('./cache-plugin'));
 server.use(prerender.removeScriptTags());
 server.use(prerender.httpHeaders());
 


### PR DESCRIPTION
## Problem

planb.academy is a pure React SPA. Crawlers receive an empty `<div id="root"></div>` — no content is visible to search engines or AI agents (GPTBot, ClaudeBot, PerplexityBot). This results in near-zero indexation of ~75K content pages across 28 languages.

## Solution

**Prerender service** — a self-hosted [prerender](https://github.com/prerender/prerender) container (headless Chromium) integrated in the Docker Compose stack.

- Traefik detects bot User-Agents via `HeadersRegexp` (priority 100) and routes them to the prerender service
- Prerender loads the page in headless Chrome, waits for `window.prerenderReady`, and returns static HTML
- Normal users are unaffected — they hit the SPA as before

**Stale-while-revalidate cache** — custom cache plugin so bots never wait after the first render:
- **Cold** (first visit): ~3s render thanks to `window.prerenderReady` signal
- **Cached** (within 24h TTL): 0.01s from in-memory cache
- **Stale** (after TTL): 0.01s from stale cache + background re-render refreshes the entry

**Testnet noindex** — nginx `map` directives inject `noindex` meta and restrictive `robots.txt` on `planbtest.academy`.

### Files changed

| File | Change |
|------|--------|
| `docker/prerender/Dockerfile` | Standalone image (Node + Chromium, non-root user) |
| `docker/prerender/server.js` | Prerender config (10s timeout, 500ms wait) |
| `docker/prerender/cache-plugin.js` | Stale-while-revalidate cache (20K entries, 24h TTL) |
| `docker/prerender/package.json` | `prerender` dependency |
| `docker/compose.yml` | Prerender service (8G memory, healthcheck, Traefik labels) |
| `apps/academy/docker/nginx.conf` | Noindex maps + dynamic robots.txt |
| `.github/workflows/ci-cd.yml` | `build_prerender` CI job |
| `apps/academy/src/main.tsx` | `window.prerenderReady = false` (init signal) |
| `apps/academy/src/providers/app.tsx` | `window.prerenderReady = true` (after first render) |

### Verified locally

| Test | Result |
|------|--------|
| Cold render (course page) | 200, 347KB, correct title, 0 scripts |
| Cache hit (same URL) | 200, 347KB, **0.006s** |
| Stale-while-revalidate (after TTL) | 200, 347KB, **0.022s** + background revalidation confirmed |

### Post-deploy verification

```bash
curl -A "Googlebot" https://planb.academy/en   # expect rendered HTML
curl -A "Mozilla" https://planb.academy/en      # expect SPA shell (no regression)
```

Monitor: container RAM via `docker stats`, crawl coverage via Google Search Console.

### Risk assessment

| Risk | Mitigation |
|------|------------|
| Chrome OOM | `memory: 8G` + `restart: always` + `shm_size: 1gb` |
| Bot not in UA list | Falls back to SPA (same as today) |
| prerenderReady never set | Falls back to pageLoadTimeout (10s) |
| **Rollback** | `docker compose stop prerender` — zero user impact |