### PR TITLE
fix: align assignment deadline fallback with single-trial-exam

### DIFF
--- a/apps/academy/src/routes/$lang/_course/courses/$courseSlug/_$courseSlug/assignment.tsx
+++ b/apps/academy/src/routes/$lang/_course/courses/$courseSlug/_$courseSlug/assignment.tsx
@@ -159,7 +159,7 @@ function Assignment() {
       : courseInfo?.assignmentStartDate || '2026-03-25T17:00:00Z',
   ).getTime();
   const endAssignmentDate = new Date(
-    courseInfo?.assignmentEndDate || '2026-04-30T11:00:00Z',
+    courseInfo?.assignmentEndDate || '2026-04-23T23:59:00',
   ).getTime();
   const currentTime = Date.now();
   const isAssignmentOpen = currentTime >= openAssignmentDate;


### PR DESCRIPTION
## Problem
The `assignment.tsx` page used a fallback `assignmentEndDate` of `2026-04-30T11:00:00Z`, while `single-trial-exam.tsx` falls back to `2026-04-23T23:59:00`. When the API doesn't return an end date, users see two inconsistent deadlines (April 30 vs April 23).

## Solution
Align the `assignment.tsx` fallback to `2026-04-23T23:59:00` so both pages display the same deadline.