### PR TITLE
fix: harden academy prerender routing

### DIFF
--- a/apps/academy/docker/nginx.conf
+++ b/apps/academy/docker/nginx.conf
@@ -180,8 +180,10 @@ http {
             # Debugging headers
             add_header X-Index-Match "true" always;
 
-            # Set the expires header to 30 seconds
-            expires 30s;
+            # Never let edge caches mix human SPA HTML with bot prerendered HTML
+            expires off;
+            add_header Cache-Control "no-store, no-cache, must-revalidate" always;
+            add_header Pragma "no-cache" always;
 
             # Replace the title with the response from the metadata request
             # For more information see

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -110,7 +110,7 @@ services:
       start_period: 30s
     labels:
       - traefik.enable=true
-      - traefik.http.routers.university-prerender-${ENV}.rule=Host(`${DOMAIN_ACADEMY}`) && Method(`GET`,`HEAD`) && HeadersRegexp(`User-Agent`, `(?i)(googlebot|bingbot|yandex|baiduspider|duckduckbot|facebookexternalhit|twitterbot|linkedinbot|slackbot|telegrambot|whatsapp|discordbot|applebot|gptbot|oai-searchbot|chatgpt-user|claudebot|claude-web|perplexitybot|google-extended|applebot-extended|amazonbot|bytespider|deepseekbot|meta-externalagent|ccbot|diffbot|petalbot)`) && PathRegexp(`^/(?:[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*)/(?:courses|live-classes|learn-anytime|tutorials|resources|events)(?:/.*)?$`)
+      - traefik.http.routers.university-prerender-${ENV}.rule=Host(`${DOMAIN_ACADEMY}`) && Method(`GET`,`HEAD`) && HeadersRegexp(`User-Agent`, `(?i)(googlebot|bingbot|yandex|baiduspider|duckduckbot|facebookexternalhit|twitterbot|linkedinbot|slackbot|telegrambot|whatsapp|discordbot|applebot|gptbot|oai-searchbot|chatgpt-user|claudebot|claude-web|perplexitybot|google-extended|applebot-extended|amazonbot|bytespider|deepseekbot|meta-externalagent|ccbot|diffbot|petalbot)`) && PathRegexp(`^/$|^/(?:[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*)/(?:courses|live-classes|learn-anytime|tutorials|resources|events)(?:/.*)?$`)
       - traefik.http.routers.university-prerender-${ENV}.entrypoints=https
       - traefik.http.routers.university-prerender-${ENV}.tls=true
       - traefik.http.routers.university-prerender-${ENV}.priority=100

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -110,7 +110,7 @@ services:
       start_period: 30s
     labels:
       - traefik.enable=true
-      - traefik.http.routers.university-prerender-${ENV}.rule=Host(`${DOMAIN_ACADEMY}`) && Method(`GET`,`HEAD`) && HeadersRegexp(`User-Agent`, `(?i)(googlebot|bingbot|yandex|baiduspider|duckduckbot|facebookexternalhit|twitterbot|linkedinbot|slackbot|telegrambot|whatsapp|discordbot|applebot|gptbot|oai-searchbot|chatgpt-user|claudebot|claude-web|perplexitybot|google-extended|applebot-extended|amazonbot|bytespider|deepseekbot|meta-externalagent|ccbot|diffbot|petalbot)`) && PathRegexp(`^/(?:[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*)/(?:live-classes|learn-anytime|tutorials|resources|events)(?:/.*)?$`)
+      - traefik.http.routers.university-prerender-${ENV}.rule=Host(`${DOMAIN_ACADEMY}`) && Method(`GET`,`HEAD`) && HeadersRegexp(`User-Agent`, `(?i)(googlebot|bingbot|yandex|baiduspider|duckduckbot|facebookexternalhit|twitterbot|linkedinbot|slackbot|telegrambot|whatsapp|discordbot|applebot|gptbot|oai-searchbot|chatgpt-user|claudebot|claude-web|perplexitybot|google-extended|applebot-extended|amazonbot|bytespider|deepseekbot|meta-externalagent|ccbot|diffbot|petalbot)`) && PathRegexp(`^/$|^/(?:[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*)/(?:live-classes|learn-anytime|tutorials|resources|events)(?:/.*)?$`)
       - traefik.http.routers.university-prerender-${ENV}.entrypoints=https
       - traefik.http.routers.university-prerender-${ENV}.tls=true
       - traefik.http.routers.university-prerender-${ENV}.priority=100

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -110,7 +110,7 @@ services:
       start_period: 30s
     labels:
       - traefik.enable=true
-      - traefik.http.routers.university-prerender-${ENV}.rule=Host(`${DOMAIN_ACADEMY}`) && Method(`GET`,`HEAD`) && HeadersRegexp(`User-Agent`, `(?i)(googlebot|bingbot|yandex|baiduspider|duckduckbot|facebookexternalhit|twitterbot|linkedinbot|slackbot|telegrambot|whatsapp|discordbot|applebot|gptbot|oai-searchbot|chatgpt-user|claudebot|claude-web|perplexitybot|google-extended|applebot-extended|amazonbot|bytespider|deepseekbot|meta-externalagent|ccbot|diffbot|petalbot)`) && PathRegexp(`^/$|^/(?:[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*)/(?:live-classes|learn-anytime|tutorials|resources|events)(?:/.*)?$`)
+      - traefik.http.routers.university-prerender-${ENV}.rule=Host(`${DOMAIN_ACADEMY}`) && Method(`GET`,`HEAD`) && HeadersRegexp(`User-Agent`, `(?i)(googlebot|bingbot|yandex|baiduspider|duckduckbot|facebookexternalhit|twitterbot|linkedinbot|slackbot|telegrambot|whatsapp|discordbot|applebot|gptbot|oai-searchbot|chatgpt-user|claudebot|claude-web|perplexitybot|google-extended|applebot-extended|amazonbot|bytespider|deepseekbot|meta-externalagent|ccbot|diffbot|petalbot)`) && PathRegexp(`^/(?:[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*)/(?:courses|live-classes|learn-anytime|tutorials|resources|events)(?:/.*)?$`)
       - traefik.http.routers.university-prerender-${ENV}.entrypoints=https
       - traefik.http.routers.university-prerender-${ENV}.tls=true
       - traefik.http.routers.university-prerender-${ENV}.priority=100

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -86,6 +86,7 @@ services:
 
   # Prerender — serves pre-rendered HTML to search engine and AI crawlers
   # Bot UA detection via Traefik HeadersRegexp, priority 100 (above academy default)
+  # Only whitelisted academy document routes are sent to prerender.
   # Source list: https://github.com/monperrus/crawler-user-agents
   prerender:
     <<: *defaults
@@ -104,12 +105,12 @@ services:
     healthcheck:
       <<: *healthcheck
       test: ['CMD', 'curl', '-sf', 'http://localhost:3000/healthz']
-      interval: 60s
-      timeout: 15s
+      interval: 15s
+      timeout: 5s
       start_period: 30s
     labels:
       - traefik.enable=true
-      - traefik.http.routers.university-prerender-${ENV}.rule=Host(`${DOMAIN_ACADEMY}`) && HeadersRegexp(`User-Agent`, `(?i)(googlebot|bingbot|yandex|baiduspider|duckduckbot|facebookexternalhit|twitterbot|linkedinbot|slackbot|telegrambot|whatsapp|discordbot|applebot|gptbot|oai-searchbot|chatgpt-user|claudebot|claude-web|perplexitybot|google-extended|applebot-extended|amazonbot|bytespider|deepseekbot|meta-externalagent|ccbot|diffbot|petalbot)`)
+      - traefik.http.routers.university-prerender-${ENV}.rule=Host(`${DOMAIN_ACADEMY}`) && Method(`GET`,`HEAD`) && HeadersRegexp(`User-Agent`, `(?i)(googlebot|bingbot|yandex|baiduspider|duckduckbot|facebookexternalhit|twitterbot|linkedinbot|slackbot|telegrambot|whatsapp|discordbot|applebot|gptbot|oai-searchbot|chatgpt-user|claudebot|claude-web|perplexitybot|google-extended|applebot-extended|amazonbot|bytespider|deepseekbot|meta-externalagent|ccbot|diffbot|petalbot)`) && PathRegexp(`^/(?:[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*)/(?:live-classes|learn-anytime|tutorials|resources|events)(?:/.*)?$`)
       - traefik.http.routers.university-prerender-${ENV}.entrypoints=https
       - traefik.http.routers.university-prerender-${ENV}.tls=true
       - traefik.http.routers.university-prerender-${ENV}.priority=100

--- a/docker/prerender/server.js
+++ b/docker/prerender/server.js
@@ -25,15 +25,29 @@ const server = prerender({
 server.use(prerender.removeScriptTags());
 server.use(prerender.httpHeaders());
 server.use(require('./cache-plugin'));
+server.use({
+  beforeSend: (req, _res, next) => {
+    req.prerender.headers = {
+      ...(req.prerender.headers || {}),
+      'Cache-Control': 'no-store, no-cache, must-revalidate',
+      Pragma: 'no-cache',
+    };
+    next();
+  },
+});
 
-// Healthcheck endpoint — returns 200 without rendering
+// Healthcheck endpoint — only healthy when prerender still has a live Chrome connection
 server.use({
   requestReceived: (req, res, next) => {
-    if (req.prerender.url === 'healthz') {
-      res.send(200, 'ok');
-    } else {
-      next();
+    if (req.prerender.url !== 'healthz') {
+      return next();
     }
+
+    if (req.server?.isBrowserConnected) {
+      return res.send(200, 'ok');
+    }
+
+    return res.send(503, 'chrome-disconnected');
   },
 });
 


### PR DESCRIPTION
## Problem

The academy bot-prerender path is too broad and too fragile:

- any matching bot user-agent can be routed to prerender, including non-document URLs like `/locales/*.json`
- bot and human HTML can be mixed by upstream caches because both variants are cacheable on the same URL
- the prerender container can stay `healthy` even when Chrome is disconnected, so cold bot renders degrade into 504s while Docker still reports the service as healthy

## Solution

- restrict Traefik prerender routing to `GET`/`HEAD` requests on the whitelisted academy document sections only:
  - `/{lang}/live-classes`
  - `/{lang}/learn-anytime`
  - `/{lang}/tutorials`
  - `/{lang}/resources`
  - `/{lang}/events`
- support richer locale tags in the whitelist regex, including forms like `zh-Hans`, `zh-Hant`, `nd-NO`, and `st-Latn`
- mark academy SPA HTML and prerendered bot HTML as `no-store`/`no-cache` to prevent edge-cache cross-contamination between human and bot variants
- make `/healthz` fail when Chrome is disconnected so container health reflects real prerender availability
- tighten healthcheck timing so unhealthy Chrome state is detected faster

## Validation

- `node --check docker/prerender/server.js`
- `docker-compose --project-directory . -f docker/compose.yml config`
- `docker run --rm --add-host api:127.0.0.1 -v "$PWD/apps/academy/docker/nginx.conf:/etc/nginx/nginx.conf:ro" -v "$PWD/apps/academy/docker/decode.js:/etc/nginx/decode.js:ro" nginx:latest nginx -t`
