### PR TITLE
fix: drop PathRegexp from prerender router (Traefik v2 incompat)

### DIFF
--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -86,7 +86,8 @@ services:
 
   # Prerender — serves pre-rendered HTML to search engine and AI crawlers
   # Bot UA detection via Traefik HeadersRegexp, priority 100 (above academy default)
-  # Only whitelisted academy document routes are sent to prerender.
+  # NOTE: Traefik v2 has no path-regex matcher (PathRegexp is v3+), so we can't
+  # whitelist document paths here. UA + Host + GET/HEAD + rate-limit is the gate.
   # Source list: https://github.com/monperrus/crawler-user-agents
   prerender:
     <<: *defaults
@@ -110,7 +111,7 @@ services:
       start_period: 30s
     labels:
       - traefik.enable=true
-      - traefik.http.routers.university-prerender-${ENV}.rule=Host(`${DOMAIN_ACADEMY}`) && Method(`GET`,`HEAD`) && HeadersRegexp(`User-Agent`, `(?i)(googlebot|bingbot|yandex|baiduspider|duckduckbot|facebookexternalhit|twitterbot|linkedinbot|slackbot|telegrambot|whatsapp|discordbot|applebot|gptbot|oai-searchbot|chatgpt-user|claudebot|claude-web|perplexitybot|google-extended|applebot-extended|amazonbot|bytespider|deepseekbot|meta-externalagent|ccbot|diffbot|petalbot)`) && PathRegexp(`^/$|^/(?:[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*)/(?:courses|live-classes|learn-anytime|tutorials|resources|events)(?:/.*)?$`)
+      - traefik.http.routers.university-prerender-${ENV}.rule=Host(`${DOMAIN_ACADEMY}`) && Method(`GET`,`HEAD`) && HeadersRegexp(`User-Agent`, `(?i)(googlebot|bingbot|yandex|baiduspider|duckduckbot|facebookexternalhit|twitterbot|linkedinbot|slackbot|telegrambot|whatsapp|discordbot|applebot|gptbot|oai-searchbot|chatgpt-user|claudebot|claude-web|perplexitybot|google-extended|applebot-extended|amazonbot|bytespider|deepseekbot|meta-externalagent|ccbot|diffbot|petalbot)`)
       - traefik.http.routers.university-prerender-${ENV}.entrypoints=https
       - traefik.http.routers.university-prerender-${ENV}.tls=true
       - traefik.http.routers.university-prerender-${ENV}.priority=100


### PR DESCRIPTION
## Problem

Bots and LLM crawlers hitting `planb.academy` received the empty SPA shell instead of prerendered HTML on mainnet — defeating the goal of #1976 and #1978.

Root cause: PR #1978 tightened the prerender router with a `PathRegexp` matcher, but mainnet runs **Traefik v2.10.5**. `PathRegexp` was added in **Traefik v3**. On v2 the rule parses as invalid and Traefik disables the router entirely:

```
error while parsing rule ...: unsupported function: PathRegexp
routerName=university-prerender-mainnet@docker
```

With the router disabled, every bot request fell through to the academy SPA router (priority ~21 from rule length). The prerender container was healthy and only received docker healthchecks — zero real traffic.

Bot-UA probe on mainnet (10 crawler UAs × 8 URLs):
- 100% returned byte-identical SPA shell (2504–3006 B)
- `x-index-match: true` on every response (academy nginx signature, not prerender)
- `docker logs mainnet-prerender-1` showed only `getting healthz` lines

## Solution

Remove `PathRegexp` from the prerender router rule. The remaining gate is still strict enough to protect the prerender pool:

- `Host(planb.academy)` — scope to the zone
- `Method(GET, HEAD)` — no POST/PUT/DELETE
- `HeadersRegexp(User-Agent, ...)` — 27-entry crawler allowlist
- `prerender-ratelimit` middleware — 2 req/s, burst 20, per-IP

Tradeoff: we lose path-level whitelisting of `/courses|live-classes|learn-anytime|tutorials|resources|events`. Bots matching the UA allowlist can now reach prerender on any GET path (e.g. `/api/…`). Acceptable because:
1. UA allowlist is already narrow (27 well-known crawlers).
2. Rate limit caps abuse at 2 req/s per source IP.
3. Prerender has its own in-memory cache (`CACHE_MAXSIZE=20000`, `CACHE_TTL=86400`).

Path-level hardening can be restored when we migrate Traefik to v3.

## Related Cloudflare fix (done out-of-band on mainnet)

Rule #4 "Cache index.html" was overriding origin `Cache-Control` (`Edge TTL: 2 min`, `Browser TTL: 5 min`), caching the SPA shell for everyone and masking bot routing entirely. Reconfigured to respect origin: **Edge TTL → "Use cache-control header if present, bypass cache if not"**, **Browser TTL → "Respect origin TTL"**. This lets the `no-store` header from #1978 flow through unchanged. No code change; configuration-only.
