### PR TITLE
fix: career portal step 4 Next button stays disabled after accepting terms

### DIFF
--- a/apps/academy/src/routes/$lang/career-portal/index.tsx
+++ b/apps/academy/src/routes/$lang/career-portal/index.tsx
@@ -1160,8 +1160,8 @@ function CareerPortal() {
                   size="m"
                   type="submit"
                   disabled={
-                    form.getValues().areTermsAccepted === false ||
-                    form.getValues().allowReceivingEmails === false
+                    !form.watch('areTermsAccepted') ||
+                    !form.watch('allowReceivingEmails')
                   }
                 >
                   {isMobile


### PR DESCRIPTION
## Problem
On the career portal legal-terms step (step 4), the **Next / Complete application** button stays disabled even after both mandatory checkboxes are ticked. Reported by a user on mobile, but reproducible on desktop too.

Root cause: the button's `disabled` prop reads `form.getValues()`, which is **not reactive** — and the checkboxes render inside a `Controller`, which re-renders only the checkbox itself, never the parent `CareerPortal` component. So ticking the boxes updates the form state but the button is never re-evaluated.

The bug is intermittent in practice: any accidental parent re-render (window focus triggering a react-query refetch, breakpoint resize, etc.) re-enables the button, which is why most users eventually got through and it went unnoticed since the feature shipped.

## Solution
Use `form.watch()` instead of `form.getValues()` for the two checkbox fields, which subscribes to changes and re-renders when they toggle (same pattern already used elsewhere, e.g. `password-reset.tsx`).

Verified end-to-end locally: without the fix the button stays disabled after checking both boxes; with the fix it enables immediately and the application submits successfully.