### PR TITLE
chore(peertube): point PeerTube at peertube.planb.academy

### DIFF
--- a/apps/academy/src/components/video-selector.tsx
+++ b/apps/academy/src/components/video-selector.tsx
@@ -11,7 +11,7 @@ import { lazy, Suspense, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TbVideo } from 'react-icons/tb';
 import ReactPlayer from 'react-player';
-import { fixEmbedUrl } from '#src/utils/misc.ts';
+import { fixEmbedUrl, PEERTUBE_HOST } from '#src/utils/misc.ts';
 import { trpc } from '#src/utils/trpc.ts';
 import { isPearApp } from '../env.ts';
 
@@ -296,7 +296,7 @@ function DisplayVideo({
       );
     }
     case VideoProvider.Peertube: {
-      const peertubeUrl = `https://peertube.planb.network/videos/embed/${idFromProvider}`;
+      const peertubeUrl = `https://${PEERTUBE_HOST}/videos/embed/${idFromProvider}`;
 
       return (
         <div className="relative pt-[56.25%]">

--- a/apps/academy/src/routes/$lang/events/$eventId.tsx
+++ b/apps/academy/src/routes/$lang/events/$eventId.tsx
@@ -33,7 +33,7 @@ import {
   getUTCOffset,
 } from '#src/utils/date.ts';
 import { resourceImgUrl } from '#src/utils/index.ts';
-import { base64ToBlob } from '#src/utils/misc.ts';
+import { base64ToBlob, PEERTUBE_HOST } from '#src/utils/misc.ts';
 import { trpc } from '#src/utils/trpc.js';
 import { ListElement2 } from '../_course/courses/$courseSlug/_$courseSlug/summer-school.tsx';
 import { AddEmailModal } from '../dashboard/-components/add-email-modal.tsx';
@@ -375,7 +375,7 @@ function EventDetails() {
                 )}
                 {event?.chatUrl && (
                   <iframe
-                    src="https://peertube.planb.network/plugins/livechat/router/webchat/room/4f4a811a-2d98-40dc-80ea-736088b408e7"
+                    src={`https://${PEERTUBE_HOST}/plugins/livechat/router/webchat/room/4f4a811a-2d98-40dc-80ea-736088b408e7`}
                     title="Chat"
                     sandbox="allow-same-origin allow-scripts allow-popups allow-forms"
                     className="w-full"

--- a/apps/academy/src/utils/misc.ts
+++ b/apps/academy/src/utils/misc.ts
@@ -33,7 +33,30 @@ export const base64ToBlob = (
   return blob;
 };
 
+/**
+ * PeerTube moved from `planb.network` to `planb.academy` when the instance was
+ * consolidated onto pba-core. Content published before the move still carries
+ * the legacy host, so URLs are normalised onto the current host before use
+ * rather than rewritten across the content repository.
+ */
+export const PEERTUBE_HOST = 'peertube.planb.academy';
+const PEERTUBE_LEGACY_HOSTS = ['peertube.planb.network'];
+
+export const normalizePeertubeHost = (src: string) =>
+  PEERTUBE_LEGACY_HOSTS.reduce(
+    (acc, legacyHost) => acc.replaceAll(legacyHost, PEERTUBE_HOST),
+    src,
+  );
+
+const isPeertubeUrl = (src: string) =>
+  [PEERTUBE_HOST, ...PEERTUBE_LEGACY_HOSTS].some((host) =>
+    src.startsWith(`https://${host}`),
+  );
+
 export const fixEmbedUrl = (src: string) => {
+  // biome-ignore lint/style/noParameterAssign: legacy PeerTube host is rewritten in place
+  src = normalizePeertubeHost(src);
+
   if (src.includes('embed')) {
     return src;
   }
@@ -53,10 +76,10 @@ export const fixEmbedUrl = (src: string) => {
     case src.includes('youtube.com'): {
       return src.replace('youtube.com/', 'youtube.com/embed/');
     }
-    case src.includes('peertube.planb.network'): {
+    case src.includes(PEERTUBE_HOST): {
       return src.replace(
-        'peertube.planb.network/videos/',
-        'peertube.planb.network/videos/embed/',
+        `${PEERTUBE_HOST}/videos/`,
+        `${PEERTUBE_HOST}/videos/embed/`,
       );
     }
     case src.includes('makertube.net'): {
@@ -73,7 +96,7 @@ export const isUrlFromValidVideoPlatform = (src: string) => {
     doesVideoUrlWorkWithReactPlayer(src) ||
     src.startsWith('https://www.rumble.com') ||
     src.startsWith('https://rumble.com') ||
-    src.startsWith('https://peertube.planb.network') ||
+    isPeertubeUrl(src) ||
     src.startsWith('https://makertube.net') ||
     src.startsWith('https://live.planb.academy/playback')
   );

--- a/pear-sync/peertube-sync.js
+++ b/pear-sync/peertube-sync.js
@@ -21,7 +21,7 @@ if (check[0].result !== 2) {
   throw new Error('Database connection failed');
 }
 
-const peerTubeBaseUrl = 'https://peertube.planb.network/api/v1/videos/';
+const peerTubeBaseUrl = 'https://peertube.planb.academy/api/v1/videos/';
 
 const now = () => new Date().toISOString();
 


### PR DESCRIPTION
## Why

PeerTube is moving off its dedicated box, and changes host in the process:

`peertube.planb.network` → **`peertube.planb.academy`**

The new instance is already installed and healthy on new box (PeerTube 8.2.3, Cloudron package 4.8.3). This PR is the application-side half of that move. 

**Do not merge until the data migration is done and DNS is cut over** 
merging early would point the academy at an empty instance.

## What changed

`peertube.planb.network` was hardcoded in five string literals across four files. It is now one exported constant, `PEERTUBE_HOST`, in `apps/academy/src/utils/misc.ts`.

The interesting part is the legacy host. Videos published before the move are referenced by **absolute URL stored in the content repository** (`bitcoin-educational-content`), not built from an id — so simply flipping the constant would have broken every existing embed. Instead, `fixEmbedUrl` normalises the legacy host onto the current one before doing anything else, and the allowlist accepts both hosts. Old content keeps working with no content-repo migration, and new URLs are emitted on the new host.

| File | Change |
|---|---|
| `apps/academy/src/utils/misc.ts` | `PEERTUBE_HOST` + `normalizePeertubeHost` + `isPeertubeUrl`; `fixEmbedUrl` normalises first; allowlist accepts both hosts |
| `apps/academy/src/components/video-selector.tsx` | builds the embed URL from `PEERTUBE_HOST` |
| `apps/academy/src/routes/$lang/events/$eventId.tsx` | livechat iframe uses `PEERTUBE_HOST` |
| `pear-sync/peertube-sync.js` | sync API base points at the new host |

## Verification

- `pnpm check-types` — **32/32 tasks successful**
- `biome check` on all four files — clean
- Behaviour exercised directly against the built module:

```
ok  https://peertube.planb.network/videos/watch/abc-123  -> https://peertube.planb.academy/videos/embed/watch/abc-123
ok  https://peertube.planb.network/videos/embed/abc-123  -> https://peertube.planb.academy/videos/embed/abc-123
ok  https://peertube.planb.network/w/abc-123             -> https://peertube.planb.academy/w/abc-123
ok  https://peertube.planb.academy/videos/watch/abc-123  -> https://peertube.planb.academy/videos/embed/watch/abc-123
ok  https://youtu.be/xyz                                 -> https://youtube.com/embed/xyz
ok  https://makertube.net/w/xyz                          -> https://makertube.net/videos/embed/xyz
ok  https://live.planb.academy/playback/presentation/1   -> unchanged

allowlist:  .network true · .academy true · makertube true · unknown host false
```

No test file was added: `apps/academy` currently has no test suite, and adding one here would introduce a convention rather than follow one.

## Known follow-ups outside this PR

- **Livechat plugin** — `$eventId.tsx` embeds the PeerTube `livechat` plugin room. That plugin (212 MB of plugin data on the old box) must be reinstalled on the pba-core instance or the chat iframe 404s.
- **Federation** — the ActivityPub actor identity is host-bound. Remote instances following `peertube.planb.network` will not follow the new host automatically.