### PR TITLE
fix(ci): surface deployment failures

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -98,8 +98,9 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha,scope=global
           cache-to: type=gha,mode=max,scope=global
-          build-args:
+          build-args: |
             BASE_IMAGE=${{ env.base }}
+            GIT_SHA=${{ github.sha }}
 
   build_academy:
     name: Build Academy

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -394,3 +394,21 @@ jobs:
         with:
           webhook_url: ${{ github.ref == 'refs/heads/mainnet' && secrets.MAINNET_WEBHOOK_URL || secrets.TESTNET_WEBHOOK_URL }}
           webhook_secret: ${{ github.ref == 'refs/heads/mainnet' && secrets.MAINNET_WEBHOOK_SECRET || secrets.TESTNET_WEBHOOK_SECRET }}
+
+      # The hook answers 200 before doing anything (it runs ci-hook.sh in the
+      # background), so a green webhook step proves nothing. Poll until the
+      # target actually serves the commit we just built.
+      - name: Verify deployed build
+        timeout-minutes: 10
+        env:
+          TARGET_URL: ${{ github.ref == 'refs/heads/mainnet' && 'https://planb.academy' || 'https://planbtest.academy' }}
+          EXPECTED_SHA: ${{ github.sha }}
+        run: |
+          echo "Waiting for ${TARGET_URL}/api/version to report ${EXPECTED_SHA}"
+          # 404 / network error means "not deployed yet": the endpoint is absent
+          # from older builds, and containers are down during pull + up.
+          until [ "$(curl -sf --max-time 10 "${TARGET_URL}/api/version" | jq -r '.sha // empty')" = "${EXPECTED_SHA}" ]; do
+            echo "Not deployed yet, retrying in 15s."
+            sleep 15
+          done
+          echo "Deployed build matches ${EXPECTED_SHA}."

--- a/apps/api/docker/Dockerfile
+++ b/apps/api/docker/Dockerfile
@@ -78,4 +78,8 @@ USER node
 
 COPY --from=installer /app .
 
+# Build identity for GET /api/version, last so it doesn't bust the cache above
+ARG GIT_SHA=unknown
+ENV GIT_SHA=$GIT_SHA
+
 CMD node apps/api/dist/src/index.js

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -50,6 +50,11 @@ function getenv<
 export const production = getenv('NODE_ENV') === 'production';
 
 /**
+ * Commit SHA of the build, injected at image build time
+ */
+export const gitSha: string = getenv('GIT_SHA', 'unknown');
+
+/**
  * Application domain (without protocol)
  */
 export const domain = getenv('DOMAIN', 'localhost:8181');

--- a/apps/api/src/routers/rest/index.ts
+++ b/apps/api/src/routers/rest/index.ts
@@ -16,6 +16,7 @@ import { createRestTranslationAudioRoutes } from './translation-audio.js';
 import { createRestTranslationDownloadRoutes } from './translation-downloads.js';
 // import { createRestTranslationUploadRoutes } from './translation-uploads.js';
 import { createRestTranslationUploadRoutes } from './translation-uploads.js';
+import { createRestVersionRoutes } from './version.js';
 
 export const createRestRouter = async (
   dependencies: Dependencies,
@@ -36,6 +37,7 @@ export const createRestRouter = async (
   createRestEventRoutes(dependencies, router);
   createRestCouponsRoutes(dependencies, router);
   createRestCalendarRoutes(dependencies, router);
+  createRestVersionRoutes(dependencies, router);
 
   return router;
 };

--- a/apps/api/src/routers/rest/version.ts
+++ b/apps/api/src/routers/rest/version.ts
@@ -1,0 +1,18 @@
+import type { Router } from 'express';
+
+import { gitSha } from '#src/config.js';
+import type { Dependencies } from '#src/dependencies.js';
+
+const startedAt = new Date().toISOString();
+
+export const createRestVersionRoutes = (
+  _dependencies: Dependencies,
+  router: Router,
+) => {
+  // curl "localhost:3000/api/version"
+  router.get('/version', (_req, res) => {
+    res.json({ sha: gitSha, startedAt });
+  });
+
+  return router;
+};


### PR DESCRIPTION
## Why

Deployments had been failing silently for ~3 months, on both staging and production, with a permanently green CI:

1. The servers' ghcr credentials had expired. An invalid token is worse than no token: Docker sends it anyway, so ghcr answers `denied` even for public images.
2. `docker compose pull` treats all 12 services as a single operation → one refusal aborts everything, and no container is updated.
3. The `github_hook_rs` receiver runs `ci-hook.sh` in the background and answers 200 before it executes → the "Deploy hook" job goes green.

Evidence: planbtest.academy was serving a bundle built on 21 April 2026, and `mainnet-academy-1` had been running for three months. Nothing made this observable: neither `/api/version` nor `/api/health` existed.

The credentials side is being handled by ops and is out of scope here. But fixing them is not enough: with no way to observe what is actually running, the next failure (re-expired token, renamed image, full disk) will hide just as long. This PR does not fix July's root cause — it makes the class of failures visible.

## How

1. **Expose the build** — unauthenticated REST route `GET /api/version` → `{ "sha", "startedAt" }`. Nothing else: no config, no dependency versions. `sha` is `unknown` in local dev.
2. **Inject the SHA** — `ARG`/`ENV GIT_SHA` in the api Dockerfile, declared last so it does not invalidate the cache of the heavy layers above, plus `GIT_SHA=${{ github.sha }}` in the `build_api` build-args.
3. **Verify** — new step after the webhook: polls `<url>/api/version` every 15s for up to 10 minutes, until `sha` matches. A 404 or network error counts as "not deployed yet" (the endpoint is absent from older builds, and containers are down during `pull` + `up`); only the timeout is fatal. Plain bash, no new dependency.

`ci-hook.sh` lives on the servers and is not touched.

## Known limitation

The first deployment of this PR cannot verify itself: `/api/version` does not exist on the build currently in place, so the step will time out after 10 minutes. That is the intended behaviour, but on that one occasion it is indistinguishable from "endpoint not shipped yet". Verification becomes reliable from the next deployment on.

## Out of scope follow-ups

- Make `blms-api`, `blms-contribute` and `blms-design-system` public on ghcr (the other four already are). This removes any dependency on a registry credential on the servers, i.e. the root cause.
- Document that `PROTECT_SYNC_ROUTE` must never be set to `false` in production: `/github/sync` would be open, and `syncLocked` only prevents parallel calls, not sequential ones.
