### PR TITLE
fix(docker): make the postgres host port configurable

### DIFF
--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -32,7 +32,8 @@ services:
     volumes:
       - ./data/postgres:/var/lib/postgresql/data
     ports:
-      - "127.0.0.1:5432:5432"  # Binds only to localhost
+      # DB_PORT lets several environments coexist on one host; container port unchanged
+      - "127.0.0.1:${DB_PORT:-5432}:5432"
 
   api:
     <<: *defaults


### PR DESCRIPTION
## Problem

`docker/compose.yml` hardcodes the postgres host port:

```yaml
ports:
  - "127.0.0.1:5432:5432"
```

Two environments therefore cannot run on the same machine: the second one fails to start
because the first already holds the port.

This blocks the ongoing infrastructure consolidation — testnet and mainnet are moving onto a
shared server. The rest of `compose.yml` is already prepared for that cohabitation: Traefik
routers have been suffixed with `${ENV}` since commit 697c44db6 ("fix: conflict between
traefik routers"), the network is `external: true`, and container names are project-prefixed.
This hardcoded port is the last remaining obstacle.

## Change

```diff
     ports:
-      - "127.0.0.1:5432:5432"  # Binds only to localhost
+      - "127.0.0.1:${DB_PORT:-5432}:5432"
```

The container port is unchanged: the API reaches postgres over the Docker network via
`POSTGRES_PORT`, which stays at `5432`. Only the host-side binding, used for admin access,
becomes configurable.

## Why a default rather than a strict form

`db_website/docker-compose.deploy.yml` uses `${DB_PORT:?DB_PORT required}`. I deliberately did
not reuse that form here: `ci-hook.sh` fetches this file from GitHub on every deployment, so a
strict form would break the first deployment of any server whose `.env` does not yet have the
variable — production included. For a change whose only purpose is to allow cohabitation, that
failure mode would be disproportionate.

With `:-5432`, existing deployments are strictly unchanged and adoption happens at each
server's own pace.

## Verification

Rendered with `docker compose config`, against testnet's real `.env`:

**Without `DB_PORT`** — current behaviour preserved:

```yaml
ports:
  - mode: ingress
    host_ip: 127.0.0.1
    target: 5432
    published: "5432"
```

**With `DB_PORT=5433`** — only the host port moves:

```yaml
    host_ip: 127.0.0.1
    target: 5432
    published: "5433"
```

`POSTGRES_PORT` is `5432` in both cases. `docker compose config -q` reports nothing.

## Next

Once merged, set `DB_PORT` in the `.env` of each environment sharing a machine (`5432` for
one, `5433` for the other). No action needed on single-environment servers.
