### PR TITLE
chore(bbb): split the recording host from the live host

### DIFF
--- a/apps/academy/src/utils/misc.ts
+++ b/apps/academy/src/utils/misc.ts
@@ -98,7 +98,7 @@ export const isUrlFromValidVideoPlatform = (src: string) => {
     src.startsWith('https://rumble.com') ||
     isPeertubeUrl(src) ||
     src.startsWith('https://makertube.net') ||
-    src.startsWith('https://live.planb.academy/playback')
+    isPlaybackBigBlueButtonUrl(src)
   );
 };
 
@@ -111,10 +111,21 @@ export const doesVideoUrlWorkWithReactPlayer = (src: string) => {
   );
 };
 
-export const isLiveBigBlueButtonUrl = (src: string) => {
-  return src.startsWith('https://live.planb.academy/rooms');
-};
+/**
+ * BigBlueButton served both live rooms and published recordings from a single
+ * host. Recordings are static files and outlive any server, so they move to a
+ * dedicated host on pba-core while `live` is kept free for an actual live
+ * server. Content published before the split still carries the legacy host, so
+ * both are accepted until the content repository is rewritten.
+ */
+export const BBB_LIVE_HOST = 'live.planb.academy';
+export const BBB_PLAYBACK_HOST = 'replay.planb.academy';
+const BBB_PLAYBACK_LEGACY_HOSTS = [BBB_LIVE_HOST];
 
-export const isPlaybackBigBlueButtonUrl = (src: string) => {
-  return src.startsWith('https://live.planb.academy/playback');
-};
+export const isLiveBigBlueButtonUrl = (src: string) =>
+  src.startsWith(`https://${BBB_LIVE_HOST}/rooms`);
+
+export const isPlaybackBigBlueButtonUrl = (src: string) =>
+  [BBB_PLAYBACK_HOST, ...BBB_PLAYBACK_LEGACY_HOSTS].some((host) =>
+    src.startsWith(`https://${host}/playback`),
+  );

--- a/apps/academy/src/utils/misc.ts
+++ b/apps/academy/src/utils/misc.ts
@@ -33,12 +33,6 @@ export const base64ToBlob = (
   return blob;
 };
 
-/**
- * PeerTube moved from `planb.network` to `planb.academy` when the instance was
- * consolidated onto pba-core. Content published before the move still carries
- * the legacy host, so URLs are normalised onto the current host before use
- * rather than rewritten across the content repository.
- */
 export const PEERTUBE_HOST = 'peertube.planb.academy';
 const PEERTUBE_LEGACY_HOSTS = ['peertube.planb.network'];
 

--- a/apps/academy/src/utils/misc.ts
+++ b/apps/academy/src/utils/misc.ts
@@ -105,13 +105,6 @@ export const doesVideoUrlWorkWithReactPlayer = (src: string) => {
   );
 };
 
-/**
- * BigBlueButton served both live rooms and published recordings from a single
- * host. Recordings are static files and outlive any server, so they move to a
- * dedicated host on pba-core while `live` is kept free for an actual live
- * server. Content published before the split still carries the legacy host, so
- * both are accepted until the content repository is rewritten.
- */
 export const BBB_LIVE_HOST = 'live.planb.academy';
 export const BBB_PLAYBACK_HOST = 'replay.planb.academy';
 const BBB_PLAYBACK_LEGACY_HOSTS = [BBB_LIVE_HOST];


### PR DESCRIPTION
## Why

BigBlueButton serves live rooms and published recordings from a single host, `live.planb.academy`. That ties an archive to a server.

The recordings are static files — `webm`, `svg`, `xml`, slides — served by nginx with no BigBlueButton process involved. They are referenced by **22 URLs across three paid courses** (`biz226`, `dev226`, `biz987` in `planB-premium-content`), so they outlive any conferencing server.

They move to **`replay.planb.academy`**, served by Surfer on `pba-core`, which frees **`live.planb.academy`** for an actual live server later. Context and measurements: `Yumi/docs/infra/bbb-migration.md`.

## What

- `BBB_LIVE_HOST` and `BBB_PLAYBACK_HOST` as named constants instead of repeated literals.
- `isPlaybackBigBlueButtonUrl` accepts **both** the new host and the legacy one.
- `isUrlFromValidVideoPlatform` now calls that predicate rather than repeating the literal, so the allowlist and the renderer can no longer drift apart.

Same shape as #1984, when PeerTube changed host.

## Additive on purpose

Both hosts satisfy the predicate, so there is **no flag day**. This can merge and deploy before anything moves; the content repository is rewritten afterwards, at its own pace.

⚠️ The legacy host must keep resolving until the content rewrite lands — `em-bbb` should not be deleted before then.

## Verification

`turbo run check-types --filter=@blms/academy` passes, `biome check` clean, and the predicates were exercised directly:

| URL | live | playback | valid platform |
|---|---|---|---|
| `replay.planb.academy/playback/presentation/2.3/<id>` | false | **true** | **true** |
| `live.planb.academy/playback/presentation/2.3/<id>` (legacy) | false | **true** | **true** |
| `live.planb.academy/rooms/<id>/join` | **true** | false | false |
| `replay.planb.academy/rooms/<id>/join` | false | false | false |
| `youtube.com/embed/<id>` | false | false | **true** |
| `evil.com/https://replay.planb.academy/playback/x` | false | false | false |