### PR TITLE
fix(prerender): register healthz before the cache plugin

### DIFF
--- a/docker/prerender/server.js
+++ b/docker/prerender/server.js
@@ -20,6 +20,22 @@ const server = prerender({
   waitAfterLastRequest: 500,
 });
 
+// Healthcheck endpoint — registered first so no other plugin (notably the cache)
+// can answer it. Only healthy when prerender still has a live Chrome connection.
+server.use({
+  requestReceived: (req, res, next) => {
+    if (req.prerender.url !== 'healthz') {
+      return next();
+    }
+
+    if (req.server?.isBrowserConnected) {
+      return res.send(200, 'ok');
+    }
+
+    return res.send(503, 'chrome-disconnected');
+  },
+});
+
 // removeScriptTags already preserves <script type="application/ld+json"> upstream,
 // so no custom stripping is needed to keep structured data safe.
 server.use(prerender.removeScriptTags());
@@ -33,21 +49,6 @@ server.use({
       Pragma: 'no-cache',
     };
     next();
-  },
-});
-
-// Healthcheck endpoint — only healthy when prerender still has a live Chrome connection
-server.use({
-  requestReceived: (req, res, next) => {
-    if (req.prerender.url !== 'healthz') {
-      return next();
-    }
-
-    if (req.server?.isBrowserConnected) {
-      return res.send(200, 'ok');
-    }
-
-    return res.send(503, 'chrome-disconnected');
   },
 });
 


### PR DESCRIPTION
Closes #1989.

`server.js` registered `cache-plugin` before the healthz plugin. The cache stores every 200 response, `healthz` included, so Docker's healthcheck received a cached `200` in 0 ms while Chrome was dead — 3363 x 200 vs 31 x 503 over 14 h, `FailingStreak=0` through 81 min of real downtime.

The healthz plugin itself was already correct. Only the registration order changes: it moves to the top of the chain, so no plugin can answer `healthz` before it. `req.server` is assigned in `onRequest` before any plugin fires, so the earlier position is safe.

### Verification

Harness stubbing the `prerender` module and firing the real plugin chain:

| case | before | after |
|---|---|---|
| Chrome alive | 200 `ok` (via healthz) | 200 `ok` (via healthz) |
| Chrome dead, healthz previously cached | **200 `ok` (via cache)** | **503 `chrome-disconnected`** |
| normal page, previously cached | 200 from cache | 200 from cache |

Page caching is unchanged.

### Effect

Docker's restart policy starts reacting to dead-Chrome again, which removes most of the 504s described in #1992 without touching the underlying kill bug.