### PR TITLE
fix(api): resolve courses by legacy index as well as id

### DIFF
--- a/packages/service-content/src/lib/courses/queries/get-course-chapters.ts
+++ b/packages/service-content/src/lib/courses/queries/get-course-chapters.ts
@@ -55,7 +55,7 @@ export const getCourseChaptersQuery = ({
         AND ch.part_id = cl.part_id
       LEFT JOIN content.courses co
         ON c.course_id = co.id
-      WHERE c.course_id = ${courseId}
+      WHERE (c.course_id = ${courseId} OR co.index = ${courseId})
       ${
         language
           ? sql`

--- a/packages/service-content/src/lib/courses/queries/get-course-meta.ts
+++ b/packages/service-content/src/lib/courses/queries/get-course-meta.ts
@@ -17,7 +17,7 @@ export const getCourseMetaQuery = (id: string, language?: string) => {
     FROM content.courses c
     JOIN content.courses_localized cl ON c.id = cl.course_id
 
-    WHERE c.id = ${id}
+    WHERE (c.id = ${id} OR c.index = ${id})
     ${language ? sql`AND cl.language = LOWER(${language})` : sql``}
   `;
 };

--- a/packages/service-content/src/lib/courses/queries/get-course.ts
+++ b/packages/service-content/src/lib/courses/queries/get-course.ts
@@ -74,7 +74,7 @@ export const getCourseQuery = (id: string, language?: string) => {
       WHERE cp.course_id = c.id AND cp.is_coordinator = false
     ) AS cp_assoc_agg ON TRUE
 
-    WHERE c.id = ${id}
+    WHERE (c.id = ${id} OR c.index = ${id})
       ${language ? sql`AND (cl.language = LOWER(${language}) OR cl.language = c.original_language)` : sql``}
     ORDER BY
       c.id,

--- a/packages/service-content/src/lib/courses/services/get-course.ts
+++ b/packages/service-content/src/lib/courses/services/get-course.ts
@@ -19,9 +19,15 @@ export const createGetCourse = ({ postgres }: Dependencies) => {
       throw new Error(`Course ${id} not found`);
     }
 
-    const parts = await postgres.exec(getCoursePartsQuery(id, course.language));
+    // `id` may be a legacy index (e.g. "btc204"); everything below keys on the UUID.
+    const parts = await postgres.exec(
+      getCoursePartsQuery(course.id, course.language),
+    );
     const chapters = await postgres.exec(
-      getCourseChaptersQuery({ courseId: id, language: course.language }),
+      getCourseChaptersQuery({
+        courseId: course.id,
+        language: course.language,
+      }),
     );
 
     const mainProfessors = await postgres.exec(


### PR DESCRIPTION
Closes #1990.

Migration `0069_eminent_lilith.sql` moved the human slug from `courses.id` to `courses.index` and turned `id` into a UUID. The lookups were never updated, so every pre-2025 course URL returns 500 and the page renders blank (`if (!course) return null`).

Three `WHERE` clauses now accept either key, and `createGetCourse` keys its downstream queries on the resolved `course.id` instead of the caller-supplied string — otherwise parts and chapters would come back empty for a legacy slug.

- `queries/get-course.ts` — `WHERE (c.id = $id OR c.index = $id)`
- `queries/get-course-meta.ts` — same
- `queries/get-course-chapters.ts` — `WHERE (c.course_id = $courseId OR co.index = $courseId)`, using the `content.courses co` join already present
- `services/get-course.ts` — parts/chapters keyed on `course.id`

### Verification

Against the mainnet database, read-only:

| query | rows |
|---|---|
| `WHERE c.id = 'btc204'` (current code) | **0** |
| `WHERE (c.id = 'btc204' OR c.index = 'btc204')` | 1 |
| same clause with the UUID | 1 |
| chapters via legacy index | 867 |
| chapters via UUID | 867 |

Ambiguity check — an `index` value colliding with a different course's `id`: **0 rows**, so the `OR` cannot match two courses. `index` also carries a `UNIQUE` constraint.

`check-types` and `biome check` pass on `@blms/service-content`.

### Deliberately out of scope

- **Canonical redirect to the UUID URL.** The legacy route serves child paths (`/overview`, `/$chapterSlug`, `/assignment`…); a naive `navigate` in the layout drops the subpath. Worth doing, but as its own change with its own testing.
- **Error typing.** `throw new Error` still maps to 500 for genuinely missing courses — that is #1991.