### PR TITLE
fix(api): return 404 for missing content and reject malformed uuids

### DIFF
--- a/apps/api/src/routers/content/courses.ts
+++ b/apps/api/src/routers/content/courses.ts
@@ -105,6 +105,8 @@ const getTeacherCourseReviewsProcedure = professorProcedure
     return createGetTeacherCourseReviews(ctx.dependencies)(input.courseId);
   });
 
+// `id` is not constrained to a uuid: courses.id is a varchar and the lookup also
+// accepts the legacy courses.index slug (e.g. "btc204"). No uuid cast, no leak.
 const getCourseProcedure = publicProcedure
   .input(
     z.object({

--- a/apps/api/src/routers/content/events.ts
+++ b/apps/api/src/routers/content/events.ts
@@ -25,7 +25,7 @@ const getRecentEventsProcedure = publicProcedure
   .query(({ ctx }) => createGetRecentEvents(ctx.dependencies)());
 
 const getEventProcedure = publicProcedure
-  .input(z.object({ id: z.string() }))
+  .input(z.object({ id: z.uuid() }))
   .output<Parser<JoinedEvent>>(joinedEventSchema)
   .query(async ({ ctx, input }) => {
     const uid = ctx.user?.uid || null;

--- a/apps/api/src/routers/content/resources.ts
+++ b/apps/api/src/routers/content/resources.ts
@@ -62,9 +62,11 @@ const createGetResourcesProcedure = () => {
   );
 };
 
+// `id` addresses a uuid-backed resource column. Without this constraint a
+// malformed id reaches Postgres and its driver message is returned to the client.
 const createGetResourceProcedure = () => {
   return publicProcedure.input(
-    z.object({ id: z.string(), language: z.string() }),
+    z.object({ id: z.uuid(), language: z.string() }),
   );
 };
 

--- a/apps/api/src/routers/content/tutorials.ts
+++ b/apps/api/src/routers/content/tutorials.ts
@@ -114,7 +114,7 @@ const getTutorialsWithProfessorNameProcedure = publicProcedure
 const getTutorialProcedure = publicProcedure
   .input(
     z.object({
-      id: z.string(),
+      id: z.uuid(),
       language: z.string(),
     }),
   )

--- a/packages/service-content/src/lib/courses/services/get-course-meta.ts
+++ b/packages/service-content/src/lib/courses/services/get-course-meta.ts
@@ -1,6 +1,6 @@
 import { firstRow } from '@blms/database';
-
 import type { CourseMeta } from '@blms/types';
+import { TRPCError } from '@trpc/server';
 import type { Dependencies } from '../../dependencies.js';
 import { getCourseMetaQuery } from '../queries/get-course-meta.js';
 
@@ -11,7 +11,10 @@ export const createGetCourseMeta = ({ postgres }: Dependencies) => {
       .then(firstRow);
 
     if (!course) {
-      throw new Error(`Course ${id} not found`);
+      throw new TRPCError({
+        code: 'NOT_FOUND',
+        message: `Course ${id} not found`,
+      });
     }
 
     return course;

--- a/packages/service-content/src/lib/courses/services/get-course.ts
+++ b/packages/service-content/src/lib/courses/services/get-course.ts
@@ -1,5 +1,6 @@
 import { firstRow } from '@blms/database';
 import type { CourseResponse } from '@blms/types';
+import { TRPCError } from '@trpc/server';
 
 import type { Dependencies } from '../../dependencies.js';
 import { getProfessorsQuery } from '../../professors/queries/get-professors.js';
@@ -16,7 +17,10 @@ export const createGetCourse = ({ postgres }: Dependencies) => {
       .then(firstRow);
 
     if (!course) {
-      throw new Error(`Course ${id} not found`);
+      throw new TRPCError({
+        code: 'NOT_FOUND',
+        message: `Course ${id} not found`,
+      });
     }
 
     // `id` may be a legacy index (e.g. "btc204"); everything below keys on the UUID.

--- a/packages/service-content/src/lib/events/services/get-event.ts
+++ b/packages/service-content/src/lib/events/services/get-event.ts
@@ -1,5 +1,6 @@
 import { firstRow } from '@blms/database';
 import type { JoinedEvent } from '@blms/types';
+import { TRPCError } from '@trpc/server';
 
 import type { Dependencies } from '../../dependencies.js';
 import { getEventQuery } from '../queries/get-event.js';
@@ -9,7 +10,10 @@ export const createGetEvent = ({ postgres }: Dependencies) => {
     const event = await postgres.exec(getEventQuery(id)).then(firstRow);
 
     if (!event) {
-      throw new Error(`Event ${id} not found`);
+      throw new TRPCError({
+        code: 'NOT_FOUND',
+        message: `Event ${id} not found`,
+      });
     }
 
     if (!isAllowed) {

--- a/packages/service-content/src/lib/resources/services/get-book.ts
+++ b/packages/service-content/src/lib/resources/services/get-book.ts
@@ -1,5 +1,6 @@
 import { firstRow } from '@blms/database';
 import type { JoinedBook } from '@blms/types';
+import { TRPCError } from '@trpc/server';
 
 import type { Dependencies } from '../../dependencies.js';
 import { getBookQuery } from '../queries/get-book.js';
@@ -9,7 +10,10 @@ export const createGetBook = ({ postgres }: Dependencies) => {
     const book = await postgres.exec(getBookQuery(id, language)).then(firstRow);
 
     if (!book) {
-      throw new Error('Book not found');
+      throw new TRPCError({
+        code: 'NOT_FOUND',
+        message: 'Book not found',
+      });
     }
 
     return book;

--- a/packages/service-content/src/lib/resources/services/get-conference-meta.ts
+++ b/packages/service-content/src/lib/resources/services/get-conference-meta.ts
@@ -1,4 +1,5 @@
 import { firstRow } from '@blms/database';
+import { TRPCError } from '@trpc/server';
 
 import type { Dependencies } from '../../dependencies.js';
 import { getConferenceMetaQuery } from '../queries/get-conference-meta.js';
@@ -10,7 +11,10 @@ export const createGetConferenceMeta = ({ postgres }: Dependencies) => {
       .then(firstRow);
 
     if (!conference) {
-      throw new Error(`Conference ${resourceId} not found`);
+      throw new TRPCError({
+        code: 'NOT_FOUND',
+        message: `Conference ${resourceId} not found`,
+      });
     }
 
     return conference;

--- a/packages/service-content/src/lib/resources/services/get-conference.ts
+++ b/packages/service-content/src/lib/resources/services/get-conference.ts
@@ -1,5 +1,6 @@
 import { firstRow } from '@blms/database';
 import type { JoinedConference } from '@blms/types';
+import { TRPCError } from '@trpc/server';
 
 import type { Dependencies } from '../../dependencies.js';
 import { getConferenceQuery } from '../queries/get-conference.js';
@@ -11,7 +12,10 @@ export const createGetConference = ({ postgres }: Dependencies) => {
       .then(firstRow);
 
     if (!conference) {
-      throw new Error(`Conference ${id} not found`);
+      throw new TRPCError({
+        code: 'NOT_FOUND',
+        message: `Conference ${id} not found`,
+      });
     }
 
     return conference;

--- a/packages/service-content/src/lib/resources/services/get-glossary-word.ts
+++ b/packages/service-content/src/lib/resources/services/get-glossary-word.ts
@@ -1,5 +1,6 @@
 import { firstRow } from '@blms/database';
 import type { JoinedGlossaryWord } from '@blms/types';
+import { TRPCError } from '@trpc/server';
 
 import type { Dependencies } from '../../dependencies.js';
 import { getGlossaryWordQuery } from '../queries/get-glossary-word.js';
@@ -14,7 +15,10 @@ export const createGetGlossaryWord = ({ postgres }: Dependencies) => {
       .then(firstRow);
 
     if (!word) {
-      throw new Error('Word not found');
+      throw new TRPCError({
+        code: 'NOT_FOUND',
+        message: 'Word not found',
+      });
     }
 
     return word;

--- a/packages/service-content/src/lib/resources/services/get-newsletter-meta.ts
+++ b/packages/service-content/src/lib/resources/services/get-newsletter-meta.ts
@@ -1,4 +1,5 @@
 import { firstRow } from '@blms/database';
+import { TRPCError } from '@trpc/server';
 
 import type { Dependencies } from '../../dependencies.js';
 import { getNewsletterMetaQuery } from '../queries/get-newsletter-meta.js';
@@ -10,7 +11,10 @@ export const createGetNewsletterMeta = ({ postgres }: Dependencies) => {
       .then(firstRow);
 
     if (!newsletter) {
-      throw new Error(`Conference ${id} not found`);
+      throw new TRPCError({
+        code: 'NOT_FOUND',
+        message: `Newsletter ${id} not found`,
+      });
     }
 
     return newsletter;

--- a/packages/service-content/src/lib/resources/services/get-project-meta.ts
+++ b/packages/service-content/src/lib/resources/services/get-project-meta.ts
@@ -1,4 +1,5 @@
 import { firstRow } from '@blms/database';
+import { TRPCError } from '@trpc/server';
 
 import type { Dependencies } from '../../dependencies.js';
 import { getProjectMetaQuery } from '../queries/get-project-meta.js';
@@ -10,7 +11,10 @@ export const createGetProjectMeta = ({ postgres }: Dependencies) => {
       .then(firstRow);
 
     if (!project) {
-      throw new Error('Project not found');
+      throw new TRPCError({
+        code: 'NOT_FOUND',
+        message: 'Project not found',
+      });
     }
 
     return project;

--- a/packages/service-content/src/lib/resources/services/get-project.ts
+++ b/packages/service-content/src/lib/resources/services/get-project.ts
@@ -1,5 +1,6 @@
 import { firstRow } from '@blms/database';
 import type { JoinedProject } from '@blms/types';
+import { TRPCError } from '@trpc/server';
 
 import type { Dependencies } from '../../dependencies.js';
 import { getProjectQuery } from '../queries/get-project.js';
@@ -11,7 +12,10 @@ export const createGetProject = ({ postgres }: Dependencies) => {
       .then(firstRow);
 
     if (!project) {
-      throw new Error('Project not found');
+      throw new TRPCError({
+        code: 'NOT_FOUND',
+        message: 'Project not found',
+      });
     }
 
     return project;

--- a/packages/service-content/src/lib/tutorials/services/get-tutorial.ts
+++ b/packages/service-content/src/lib/tutorials/services/get-tutorial.ts
@@ -1,6 +1,6 @@
 import { firstRow } from '@blms/database';
-
 import type { GetTutorialResponse } from '@blms/types';
+import { TRPCError } from '@trpc/server';
 import type { Dependencies } from '../../dependencies.js';
 import { getProfessorQuery } from '../../professors/queries/get-professor.js';
 import { formatProfessor } from '../../professors/services/utils.js';
@@ -18,7 +18,10 @@ export const createGetTutorial = ({ postgres }: Dependencies) => {
       .then(firstRow);
 
     if (!tutorial) {
-      throw new Error('Tutorial not found');
+      throw new TRPCError({
+        code: 'NOT_FOUND',
+        message: 'Tutorial not found',
+      });
     }
 
     const professor = tutorial.professorId


### PR DESCRIPTION
Closes #1991. **Stacked on #1995** — base is `fix/legacy-course-slug-lookup`, retarget to `dev` once that merges.

### 1. Missing content was reported as a server error

Content read services threw a bare `Error`, which tRPC maps to `INTERNAL_SERVER_ERROR`:

```
[request] b753e948a6c84101 ERROR (content.getCourse): Course lnp201 not found TRPCError INTERNAL_SERVER_ERROR
[request] b753e948a6c84101 GET /api/trpc/content.getCourse took 2.344866ms (500)
```

Now `TRPCError({ code: 'NOT_FOUND' })`, following the pattern already used in `translations/services/content-management.ts`. Eleven services: course, course-meta, event, conference, conference-meta, newsletter-meta, book, glossary-word, project, project-meta, tutorial.

Scoped to the procedures with production evidence of 500s. The remaining `throw new Error` sites in `service-content` (blog, professor, legal, lecture, movie, chapter…) follow the same pattern and are worth a follow-up sweep, but they are not implicated here.

Drive-by: `get-newsletter-meta.ts` said `Conference ${id} not found` — copy-paste, corrected on the line already being touched.

### 2. Malformed ids reached Postgres

`invalid input syntax for type uuid: "19"` and similar driver messages were returned to clients, from crawlers hitting truncated URLs. `z.uuid()` on the three uuid-backed inputs turns those into Zod 400s:

- `resources.ts` `createGetResourceProcedure` — one helper, covers book/conference/movie/newsletter/podcast/project/…
- `tutorials.ts` `getTutorialProcedure`
- `events.ts` `getEventProcedure`

**`getCourse` is deliberately excluded**, and this contradicts the suggestion in #1991. `content.courses.id` is `character varying`, not `uuid` — verified against `information_schema` — and after #1995 the lookup legitimately accepts the legacy `index` slug. Adding `.uuid()` there would re-break every legacy URL that PR just fixed. A comment records why.

Every `id` caller of these procedures passes a uuid extracted from the URL (`getNameAndIdFromUrl`), and `getEvent` in `notifications/index.tsx` is guarded by `enabled: !!eventId` — so no legitimate call becomes a 400.

### Verification

`bun test` against the real service with the query module mocked:

```
missing event surfaces as a 404, not a 500 — 1 pass
```

Status mapping confirmed via `getHTTPStatusCodeFromError`: `NOT_FOUND` -> 404, `BAD_REQUEST` -> 400, `INTERNAL_SERVER_ERROR` -> 500. The error formatter in `trpc/index.ts` sets no `httpStatus` override.

`check-types` passes on `@blms/api` and `@blms/service-content`; `biome check` clean.

### Front impact

None expected. These queries have no custom `retry` predicate, so TanStack Query treats 404 and 500 identically, and the components already render nothing when `data` is undefined.