### PR TITLE
fix(prerender): escalate chrome kill to SIGKILL and bound memory

### DIFF
--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -108,7 +108,12 @@ services:
     environment:
       PORT: "3000"
       CACHE_MAXSIZE: "20000"
+      CACHE_MAXBYTES: "536870912"
       CACHE_TTL: "86400"
+      # V8 defaults to ~2G regardless of the 8G cgroup limit below, and hitting
+      # it is a hard crash rather than an eviction. Keep the heap under the
+      # cache ceiling plus headroom so eviction happens first.
+      NODE_OPTIONS: "--max-old-space-size=3072"
     expose:
       - 3000
     shm_size: 1gb

--- a/docker/prerender/cache-plugin.js
+++ b/docker/prerender/cache-plugin.js
@@ -8,21 +8,43 @@
  *
  * Env vars:
  *   CACHE_MAXSIZE  — max entries (default 20000)
+ *   CACHE_MAXBYTES — max total content bytes (default 512 MiB)
  *   CACHE_TTL      — fresh duration in seconds (default 86400 = 24h)
  */
 
 const CACHE_MAXSIZE = Number.parseInt(process.env.CACHE_MAXSIZE, 10) || 20000;
+const CACHE_MAXBYTES =
+  Number.parseInt(process.env.CACHE_MAXBYTES, 10) || 512 * 1024 * 1024;
 const CACHE_TTL_MS =
   (Number.parseInt(process.env.CACHE_TTL, 10) || 86400) * 1000;
 
 // Simple LRU via Map (insertion-order iteration, delete+re-set to refresh)
-const cache = new Map(); // url → { content, createdAt }
+const cache = new Map(); // url → { content, bytes, createdAt }
 const revalidating = new Set(); // urls currently being re-rendered
+let cacheBytes = 0;
 
+function store(url, content) {
+  drop(url);
+  const bytes = Buffer.byteLength(content);
+  cache.set(url, { content, bytes, createdAt: Date.now() });
+  cacheBytes += bytes;
+  evictIfNeeded();
+}
+
+function drop(url) {
+  const entry = cache.get(url);
+  if (!entry) return;
+  cacheBytes -= entry.bytes;
+  cache.delete(url);
+}
+
+// An entry is a full HTML page, so the entry count alone is not a memory bound:
+// 20000 pages overran V8's default heap and crashed the process.
 function evictIfNeeded() {
-  while (cache.size > CACHE_MAXSIZE) {
+  while (cache.size > CACHE_MAXSIZE || cacheBytes > CACHE_MAXBYTES) {
     const oldest = cache.keys().next().value;
-    cache.delete(oldest);
+    if (oldest === undefined) return;
+    drop(oldest);
   }
 }
 
@@ -63,9 +85,7 @@ module.exports = {
           });
           response.on('end', () => {
             if (response.statusCode === 200 && body.length > 0) {
-              cache.delete(url);
-              cache.set(url, { content: body, createdAt: Date.now() });
-              evictIfNeeded();
+              store(url, body);
               console.log(`[cache] revalidated: ${url} (${body.length} bytes)`);
             }
             revalidating.delete(url);
@@ -82,13 +102,7 @@ module.exports = {
 
   beforeSend: (req, _res, next) => {
     if (!req.prerender.cacheHit && req.prerender.statusCode === 200) {
-      const url = req.prerender.url;
-      cache.delete(url);
-      cache.set(url, {
-        content: req.prerender.content,
-        createdAt: Date.now(),
-      });
-      evictIfNeeded();
+      store(req.prerender.url, req.prerender.content);
     }
     next();
   },

--- a/docker/prerender/server.js
+++ b/docker/prerender/server.js
@@ -20,6 +20,35 @@ const server = prerender({
   waitAfterLastRequest: 500,
 });
 
+// prerender@5.21.6 stops Chrome with a bare SIGINT and then waits for the
+// child's 'close' event to respawn it. Chrome ignores SIGINT often enough that
+// no 'close' ever fires: isBrowserConnected stays false and every render waits
+// 20s then 504s, until the next scheduled recycle 10 minutes later. Escalate to
+// SIGKILL so a kill always produces a close, and therefore always a respawn.
+const KILL_GRACE_MS =
+  Number.parseInt(process.env.CHROME_KILL_GRACE_MS, 10) || 5000;
+const browser = server.browser;
+const gracefulKill = browser.kill.bind(browser);
+
+browser.kill = function killWithEscalation() {
+  const child = browser.chromeChild;
+  gracefulKill();
+  if (!child || child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+
+  const escalation = setTimeout(() => {
+    if (child.exitCode === null && child.signalCode === null) {
+      console.log(
+        `[chrome] SIGINT ignored after ${KILL_GRACE_MS}ms, sending SIGKILL`,
+      );
+      child.kill('SIGKILL');
+    }
+  }, KILL_GRACE_MS);
+  escalation.unref();
+  child.once('close', () => clearTimeout(escalation));
+};
+
 // Healthcheck endpoint — registered first so no other plugin (notably the cache)
 // can answer it. Only healthy when prerender still has a live Chrome connection.
 server.use({


### PR DESCRIPTION
Closes #1992. **Stacked on #1994** — base is `fix/prerender-healthz-cache-bypass`, retarget to `dev` once that merges.

Two independent defects in the same service, both present since `docker/prerender/` was introduced (3d37684ad).

### 1. A Chrome that ignores SIGINT is never replaced

`prerender@5.21.6` recycles Chrome every 600 s. `chrome.kill()` sends a bare `SIGINT` to `chromeChild`, and the respawn is driven by the child's `close` event. When Chrome ignores the signal no `close` ever fires, `isBrowserConnected` stays false, and every cache-miss waits 20 s in `waitForBrowserToConnect` before returning 504 — until the next scheduled recycle finally reaps the process.

Measured over 14 h: 75 recycles, **8 failed**, 167 x 504, 4893 s of downtime (9.7 % wall-clock) in 8 windows of ~10 min. Latency is bimodal — successes 2932 ms p50 / 6094 ms max, every 504 on a flat plateau at 20012-20043 ms — which rules out slow pages.

`browser.kill` is wrapped to escalate to `SIGKILL` after a grace period (`CHROME_KILL_GRACE_MS`, default 5000). The timer is cleared on `close` and `unref`'d, so the graceful path is untouched. Wrapping in our `server.js` rather than patching the dependency keeps the change inside this repo.

### 2. Node heap leak

2026-08-01T02:50:50Z: `FATAL ERROR: Reached heap limit`, Mark-Compact 2047.3 -> 2046.9 MB, V8 uptime 30.93 h matching container creation. `OOMKilled=false` — this is V8's default ~2 GiB `max-old-space`, not the 8 GiB cgroup limit. `--js-flags=--max-old-space-size=512` sits in `chromeFlags`, so it applies to Chromium, not to Node.

The cache was bounded at 20000 **entries** with no byte ceiling, and an entry is a full HTML page. Now bounded by both: `CACHE_MAXBYTES` (default 512 MiB) alongside `CACHE_MAXSIZE`, with all writes going through a single `store()` that maintains the running total. `NODE_OPTIONS=--max-old-space-size=3072` is set so the heap sits above the cache ceiling and below the cgroup limit — eviction happens before any crash.

### Verification

Harness driving the real `server.js` against a child process that installs a no-op `SIGINT` handler, reproducing the production failure exactly:

```
child alive before kill: true
after SIGINT + 300ms  -> alive: true      (ignores SIGINT, as in prod)
[chrome] SIGINT ignored after 700ms, sending SIGKILL
after grace + SIGKILL -> dead: true | signal: SIGKILL
```

Graceful path, with a child that does honour SIGINT:

```
died on SIGINT: true
SIGKILL escalation skipped: true
```

Byte eviction, cap set to 1000 B, three 400 B entries inserted:

```
/a evicted: true | /c kept: true
```

`biome check` and `node --check` clean on `docker/prerender/`.

### Note

#1994 already removes most of the user-visible symptom by letting Docker's healthcheck restart a dead-Chrome container. This PR fixes the cause, so the container stops needing to be restarted at all.